### PR TITLE
fix: wrap logging + new tests (#1)

### DIFF
--- a/src/secretgate/__init__.py
+++ b/src/secretgate/__init__.py
@@ -1,3 +1,3 @@
 """secretgate — lean security proxy for AI coding tools."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/secretgate/cli.py
+++ b/src/secretgate/cli.py
@@ -186,6 +186,11 @@ def _find_available_port(preferred: int, max_attempts: int = 20) -> int:
     )
 
 
+def _default_log_dir() -> Path:
+    """Return the default log directory (~/.secretgate)."""
+    return Path.home() / ".secretgate"
+
+
 @main.command(context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
 @click.option(
     "--forward-proxy-port",
@@ -202,17 +207,32 @@ def _find_available_port(preferred: int, max_attempts: int = 20) -> int:
     default="redact",
     help="How to handle detected secrets",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Stream proxy logs to stderr (in addition to the log file)",
+)
+@click.option(
+    "--log-file",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Log file path (default: ~/.secretgate/wrap.log, set to /dev/null to disable)",
+)
 @click.pass_context
-def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
+def wrap(ctx, forward_proxy_port: int, port: int, mode: str, verbose: bool, log_file: Path | None):
     """Run a command with all traffic routed through secretgate.
 
     Starts the forward proxy in the background, sets proxy env vars,
     and runs the given command. Stops the proxy when the command exits.
 
+    Proxy logs are written to ~/.secretgate/wrap.log by default (or
+    $SECRETGATE_LOG_FILE). Use --verbose / -v to also stream them to stderr.
+
     \b
     Examples:
         secretgate wrap -- claude
-        secretgate wrap -- curl https://example.com
+        secretgate wrap -v -- claude
         secretgate wrap --mode audit -- bash
         secretgate wrap -- git push
     """
@@ -235,6 +255,17 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
         click.echo("Example: secretgate wrap -- claude")
         return
 
+    # Resolve log file path: explicit flag > env var > default
+    if log_file is None:
+        env_log = os.environ.get("SECRETGATE_LOG_FILE")
+        if env_log:
+            log_file = Path(env_log)
+        else:
+            log_file = _default_log_dir() / "wrap.log"
+
+    # Ensure the log directory exists
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
     # Find available ports (auto-increment if already in use)
     forward_proxy_port = _find_available_port(forward_proxy_port)
     port = _find_available_port(port)
@@ -255,6 +286,7 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
     click.echo(
         f"Starting secretgate (port {port}, forward proxy {forward_proxy_port}, mode {mode})..."
     )
+    click.echo(f"Logs: {log_file}")
 
     # On Windows, create a new process group so we can kill the entire tree
     popen_kwargs = {}
@@ -270,6 +302,14 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
         if secretgate_bin != sys.executable
         else [sys.executable, "-m", "secretgate", "serve"]
     )
+
+    # Open log file for writing — proxy stdout and stderr both go here
+    log_fh = open(log_file, "a")
+
+    # In verbose mode, we tee stderr to both the log file and the terminal.
+    # We use a pipe + background reader thread to avoid blocking.
+    stderr_target = subprocess.PIPE if verbose else log_fh
+
     server_proc = subprocess.Popen(
         [
             *server_cmd,
@@ -280,10 +320,29 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
             "--mode",
             mode,
         ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
+        stdout=log_fh,
+        stderr=stderr_target,
         **popen_kwargs,
     )
+
+    # If verbose, start a thread that reads stderr and writes to both log + terminal
+    tee_thread = None
+    if verbose and server_proc.stderr:
+        import threading
+
+        def _tee_stderr():
+            try:
+                for line in server_proc.stderr:
+                    decoded = line.decode(errors="replace") if isinstance(line, bytes) else line
+                    sys.stderr.write(decoded)
+                    sys.stderr.flush()
+                    log_fh.write(decoded)
+                    log_fh.flush()
+            except (ValueError, OSError):
+                pass  # file closed during shutdown
+
+        tee_thread = threading.Thread(target=_tee_stderr, daemon=True)
+        tee_thread.start()
 
     def _cleanup_server():
         """Kill the server process — registered with atexit for robustness."""
@@ -294,6 +353,10 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
             except subprocess.TimeoutExpired:
                 server_proc.kill()
                 server_proc.wait(timeout=2)
+        try:
+            log_fh.close()
+        except (ValueError, OSError):
+            pass
 
     atexit.register(_cleanup_server)
 
@@ -301,9 +364,15 @@ def wrap(ctx, forward_proxy_port: int, port: int, mode: str):
     for _ in range(50):
         # Check if the server process died early
         if server_proc.poll() is not None:
-            stderr_out = (
-                server_proc.stderr.read().decode(errors="replace") if server_proc.stderr else ""
-            )
+            stderr_out = ""
+            if verbose and server_proc.stderr:
+                stderr_out = server_proc.stderr.read().decode(errors="replace")
+            else:
+                # Read from log file for error reporting
+                try:
+                    stderr_out = log_file.read_text()[-500:]
+                except OSError:
+                    pass
             click.echo(
                 f"Error: secretgate exited unexpectedly (code {server_proc.returncode})", err=True
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for CLI commands and wrap logging (Issue #1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from secretgate.cli import main, _default_log_dir, _find_available_port
+
+
+class TestDefaultLogDir:
+    def test_returns_home_secretgate(self):
+        result = _default_log_dir()
+        assert result == Path.home() / ".secretgate"
+
+
+class TestFindAvailablePort:
+    def test_finds_free_port(self):
+        # Port 0 is never in use for TCP connect — but _find_available_port
+        # tries to connect, so any unused port should be returned.
+        port = _find_available_port(19876)
+        assert isinstance(port, int)
+        assert port >= 19876
+
+
+class TestWrapCommand:
+    def test_wrap_no_command_shows_usage(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["wrap", "--"])
+        assert "Usage:" in result.output or result.exit_code == 0
+
+    def test_wrap_help_shows_log_options(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["wrap", "--help"])
+        assert "--verbose" in result.output
+        assert "--log-file" in result.output
+        assert "wrap.log" in result.output
+
+    def test_wrap_respects_env_log_file(self, tmp_path):
+        """SECRETGATE_LOG_FILE env var should override default log path."""
+        # Verify the env var name is in the help text
+        runner = CliRunner()
+        result = runner.invoke(main, ["wrap", "--help"])
+        assert "SECRETGATE_LOG_FILE" in result.output
+
+
+class TestScanCommand:
+    def test_scan_no_secrets(self, tmp_path):
+        f = tmp_path / "clean.txt"
+        f.write_text("just normal text here")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(f)])
+        assert "No secrets found" in result.output
+        assert result.exit_code == 0
+
+    def test_scan_finds_secrets(self, tmp_path):
+        f = tmp_path / "secrets.txt"
+        f.write_text("key=AKIAIOSFODNN7EXAMPLE\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(f)])
+        assert "secret(s) found" in result.output
+        assert result.exit_code == 1
+
+    def test_scan_stdin(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan"], input="AKIAIOSFODNN7EXAMPLE\n")
+        assert "secret(s) found" in result.output
+        assert result.exit_code == 1
+
+    def test_scan_stdin_clean(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan"], input="hello world\n")
+        assert "No secrets found" in result.output
+        assert result.exit_code == 0
+
+    def test_scan_multiple_files(self, tmp_path):
+        f1 = tmp_path / "a.txt"
+        f1.write_text("AKIAIOSFODNN7EXAMPLE\n")
+        f2 = tmp_path / "b.txt"
+        f2.write_text("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(f1), str(f2)])
+        assert result.exit_code == 1
+        assert "secret(s) found" in result.output
+
+
+class TestServeCommand:
+    def test_serve_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["serve", "--help"])
+        assert "--port" in result.output
+        assert "--mode" in result.output
+        assert "--forward-proxy-port" in result.output
+
+
+class TestCACommands:
+    def test_ca_init(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(main, ["ca", "init", "--certs-dir", str(tmp_path / "certs")])
+        assert result.exit_code == 0
+        assert (tmp_path / "certs" / "ca.crt").exists()
+
+    def test_ca_path(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(main, ["ca", "path", "--certs-dir", str(tmp_path / "certs")])
+        assert "ca.crt" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,126 @@
+"""Tests for configuration loading and env var overrides."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import yaml
+
+from secretgate.config import Config
+
+
+class TestConfigDefaults:
+    def test_default_port(self):
+        cfg = Config()
+        assert cfg.port == 8080
+
+    def test_default_host(self):
+        cfg = Config()
+        assert cfg.host == "127.0.0.1"
+
+    def test_default_mode(self):
+        cfg = Config()
+        assert cfg.mode == "redact"
+
+    def test_default_no_forward_proxy(self):
+        cfg = Config()
+        assert cfg.forward_proxy_port is None
+
+    def test_default_detect_secrets_off(self):
+        cfg = Config()
+        assert cfg.use_detect_secrets is False
+
+
+class TestConfigLoad:
+    def test_load_with_no_file(self):
+        cfg = Config.load(None)
+        assert cfg.port == 8080
+        # Should have default providers
+        assert "openai" in cfg.providers
+        assert "anthropic" in cfg.providers
+
+    def test_load_from_yaml(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({
+            "port": 9090,
+            "mode": "block",
+            "forward_proxy_port": 8888,
+            "providers": {
+                "custom": "https://custom.example.com",
+            },
+        }))
+        cfg = Config.load(config_file)
+        assert cfg.port == 9090
+        assert cfg.mode == "block"
+        assert cfg.forward_proxy_port == 8888
+        assert "custom" in cfg.providers
+        assert cfg.providers["custom"].base_url == "https://custom.example.com"
+
+    def test_load_provider_with_dict(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({
+            "providers": {
+                "custom": {
+                    "base_url": "https://api.example.com",
+                    "auth_header": "X-Api-Key",
+                },
+            },
+        }))
+        cfg = Config.load(config_file)
+        assert cfg.providers["custom"].auth_header == "X-Api-Key"
+
+    def test_env_var_overrides(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({"port": 9090}))
+        env = {
+            "SECRETGATE_PORT": "7777",
+            "SECRETGATE_MODE": "audit",
+            "SECRETGATE_HOST": "0.0.0.0",
+            "SECRETGATE_LOG_LEVEL": "debug",
+            "SECRETGATE_FORWARD_PROXY_PORT": "9999",
+        }
+        with patch.dict(os.environ, env):
+            cfg = Config.load(config_file)
+        assert cfg.port == 7777
+        assert cfg.mode == "audit"
+        assert cfg.host == "0.0.0.0"
+        assert cfg.log_level == "debug"
+        assert cfg.forward_proxy_port == 9999
+
+    def test_env_detect_secrets(self):
+        with patch.dict(os.environ, {"SECRETGATE_DETECT_SECRETS": "true"}):
+            cfg = Config.load(None)
+        assert cfg.use_detect_secrets is True
+
+    def test_env_signatures_path(self, tmp_path):
+        sigs = tmp_path / "sigs.yaml"
+        sigs.write_text("[]")
+        with patch.dict(os.environ, {"SECRETGATE_SIGNATURES": str(sigs)}):
+            cfg = Config.load(None)
+        assert cfg.signatures_path == sigs
+
+    def test_env_certs_dir(self, tmp_path):
+        with patch.dict(os.environ, {"SECRETGATE_CERTS_DIR": str(tmp_path)}):
+            cfg = Config.load(None)
+        assert cfg.certs_dir == tmp_path
+
+    def test_passthrough_domains(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({
+            "passthrough_domains": ["example.com", "other.test"],
+        }))
+        cfg = Config.load(config_file)
+        assert cfg.passthrough_domains == ["example.com", "other.test"]
+
+    def test_empty_config_file(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("")
+        cfg = Config.load(config_file)
+        # Should still work with defaults
+        assert cfg.port == 8080
+
+    def test_nonexistent_config_file(self, tmp_path):
+        # load() with a path that doesn't exist should just use defaults
+        cfg = Config.load(tmp_path / "nonexistent.yaml")
+        assert cfg.port == 8080

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+"""Test version consistency between __init__.py and pyproject.toml."""
+
+from pathlib import Path
+
+import secretgate
+
+
+def test_version_matches_pyproject():
+    """__init__.py version should match pyproject.toml."""
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    content = pyproject.read_text()
+    # Extract version from pyproject.toml
+    for line in content.splitlines():
+        if line.strip().startswith("version"):
+            pyproject_version = line.split("=", 1)[1].strip().strip('"')
+            break
+    else:
+        raise AssertionError("version not found in pyproject.toml")
+    assert secretgate.__version__ == pyproject_version
+
+
+def test_version_is_semver():
+    """Version should look like a semantic version."""
+    parts = secretgate.__version__.split(".")
+    assert len(parts) >= 2
+    assert all(p.isdigit() for p in parts[:3] if p)


### PR DESCRIPTION
## Summary

Fixes #1 — **secretgate wrap: logs are silently discarded**

### Changes

**Wrap logging (Issue #1):**
- Proxy logs now write to `~/.secretgate/wrap.log` by default (directory created automatically)
- `SECRETGATE_LOG_FILE` env var overrides the default log path
- `--log-file` flag for explicit log file path
- `--verbose / -v` flag streams logs to stderr in addition to the log file (via a tee thread)
- Log file path is printed on startup so users always know where to look

**Version fix:**
- `__init__.py` was `0.1.0` while `pyproject.toml` was `0.2.0` — now consistent at `0.2.0`

**New tests (30 added, 56 → 86):**
- `test_cli.py` — CLI command tests: wrap help/options, scan (files + stdin), serve help, ca init/path
- `test_config.py` — Config loading: defaults, YAML parsing, env var overrides, provider configs, passthrough domains, edge cases
- `test_version.py` — Version consistency between `__init__.py` and `pyproject.toml`, semver format

All 86 tests pass, ruff check is clean.