### PR TITLE
docs: add branch strategy and contributing guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,14 @@ Lean security proxy for AI coding tools — scans and redacts secrets before the
 - **Placeholders**: `REDACTED<aws-access-key:a1b2c3d4e5f6>` — deterministic (same secret = same placeholder), self-documenting type identifier + truncated SHA-256 hash
 - **Deduplication**: scanner deduplicates matches by value; redactor does a second pass `result.replace()` to catch repeated occurrences
 
+## Branch strategy
+
+- `main` is protected — all changes go through PRs with at least 1 approving review
+- Squash merge only — each PR becomes a single commit on `main`
+- Feature branches: `feat/...`, `fix/...`, `chore/...`
+- Feature branches are auto-deleted after merge
+- Never push directly to `main`
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -325,7 +325,28 @@ Drop patterns in `~/.secretgate/signatures.yaml` or pass `--signatures /path/to/
     - Database URL: "myco_db://.*@prod\\.mycompany\\.com"
 ```
 
-## Development
+## Contributing
+
+We welcome contributions! Here's how we work:
+
+### Branch strategy
+
+- **`main`** is the production branch — always deployable, published to PyPI
+- All changes go through **feature branches** and **pull requests**
+- Branch naming: `feat/...`, `fix/...`, `chore/...`
+- PRs require **1 approving review** before merging
+- **Squash merge only** — keeps `main` history clean (one commit per PR)
+- Feature branches are auto-deleted after merge
+
+### Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes, ensure tests pass (`pytest tests/ -v`) and lint is clean (`ruff check src/ tests/`)
+3. Open a PR against `main`
+4. Get a review, address feedback
+5. Maintainer squash-merges once approved
+
+### Development setup
 
 ```bash
 git clone https://github.com/secretgate/secretgate.git
@@ -341,7 +362,7 @@ pytest tests/ -v
 ruff check src/ tests/
 ```
 
-## Pre-commit hooks
+### Pre-commit hooks
 
 secretgate includes pre-commit hooks for development. After `pip install -e ".[dev]"`:
 


### PR DESCRIPTION
## Summary
- Add "Contributing" section to README with branch strategy, PR workflow, and development setup
- Add "Branch strategy" section to CLAUDE.md so AI assistants follow the protected-main workflow
- Documents the rules configured on the repo: squash merge only, 1 required review, auto-delete branches

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md is picked up by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)