### PR TITLE
fix: prevent chunked response relay from blocking on small responses

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -462,16 +462,20 @@ class _ConnectionHandler:
             elif "chunked" in transfer_encoding:
                 # Stream chunked data through until we see the terminal chunk
                 buf = resp_body_start
-                while True:
-                    chunk = await upstream_reader.read(65536)
-                    if not chunk:
-                        return
-                    client_writer.write(chunk)
-                    await client_writer.drain()
-                    # Check for end of chunked encoding (0\r\n\r\n)
-                    buf = buf[-7:] + chunk  # keep tail for boundary detection (pattern is 7 bytes)
-                    if b"\r\n0\r\n\r\n" in buf or buf.startswith(b"0\r\n\r\n"):
-                        break
+                # Check if the terminal chunk is already in the initial data
+                if not (b"\r\n0\r\n\r\n" in buf or buf.startswith(b"0\r\n\r\n")):
+                    while True:
+                        chunk = await upstream_reader.read(65536)
+                        if not chunk:
+                            return
+                        client_writer.write(chunk)
+                        await client_writer.drain()
+                        # Check for end of chunked encoding (0\r\n\r\n)
+                        buf = (
+                            buf[-7:] + chunk
+                        )  # keep tail for boundary detection (pattern is 7 bytes)
+                        if b"\r\n0\r\n\r\n" in buf or buf.startswith(b"0\r\n\r\n"):
+                            break
             else:
                 # No content-length, no chunked — read until connection close
                 try:


### PR DESCRIPTION
## Summary
- When a chunked HTTP response fits entirely in the initial read buffer (including the terminal `0\r\n\r\n` chunk), the relay loop would block waiting for more data that never comes
- Fix: check for the terminal chunk in the initial buffer before entering the read loop

## Test plan
- [x] Verify small chunked responses (e.g. short API replies) complete without hanging
- [x] Verify large streaming responses (SSE) still relay correctly
- [x] Run `pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)