### PR TITLE
feat: replace hand-rolled chunked parser with h11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "structlog>=24.0",
     "cryptography>=42.0",
     "certifi>=2024.0",
+    "h11>=0.14",
 ]
 
 [project.urls]

--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -7,9 +7,11 @@ Handles HTTP CONNECT tunnels by performing TLS MITM with generated certs.
 from __future__ import annotations
 
 import asyncio
+import re
 import ssl
 from urllib.parse import urlparse
 
+import h11
 import structlog
 
 from secretgate.certs import CertAuthority
@@ -18,29 +20,6 @@ from secretgate.scan import BlockedError, TextScanner
 logger = structlog.get_logger()
 
 MAX_BUFFER_SIZE = 10 * 1024 * 1024  # 10MB
-
-
-def _decode_chunked(data: bytes) -> bytes:
-    """Decode HTTP chunked transfer-encoded bytes into raw body bytes."""
-    result = b""
-    pos = 0
-    while pos < len(data):
-        end = data.find(b"\r\n", pos)
-        if end == -1:
-            break
-        size_str = data[pos:end].split(b";")[0].strip()
-        if not size_str:
-            break
-        try:
-            size = int(size_str, 16)
-        except ValueError:
-            break
-        if size == 0:
-            break
-        pos = end + 2
-        result += data[pos : pos + size]
-        pos += size + 2  # skip trailing \r\n after chunk data
-    return result
 
 
 class ForwardProxyServer:
@@ -310,19 +289,48 @@ class _ConnectionHandler:
                         break
                     body += chunk
             elif "chunked" in req_transfer:
-                # Read all raw chunked data then decode to plain bytes so
+                # Use h11 to decode chunked body into plain bytes so
                 # redaction works on content only (not chunk-size framing) and
                 # so we can switch to Content-Length framing for forwarding.
                 was_chunked = True
-                raw_chunked = body
+                h11_conn = h11.Connection(our_role=h11.SERVER)
+                h11_conn.receive_data(req_header_data)
+
+                body_parts: list[bytes] = []
+                done = False
                 while True:
+                    event = h11_conn.next_event()
+                    if isinstance(event, h11.Request):
+                        continue
+                    elif isinstance(event, h11.Data):
+                        body_parts.append(bytes(event.data))
+                    elif isinstance(event, h11.EndOfMessage):
+                        done = True
+                        break
+                    elif event is h11.NEED_DATA:
+                        break
+                    else:
+                        break
+
+                while not done:
                     chunk = await client_reader.read(65536)
                     if not chunk:
                         break
-                    raw_chunked += chunk
-                    if b"\r\n0\r\n\r\n" in raw_chunked or raw_chunked.endswith(b"0\r\n\r\n"):
-                        break
-                body = _decode_chunked(raw_chunked)
+                    h11_conn.receive_data(chunk)
+                    while True:
+                        event = h11_conn.next_event()
+                        if isinstance(event, h11.Data):
+                            body_parts.append(bytes(event.data))
+                        elif isinstance(event, h11.EndOfMessage):
+                            done = True
+                            break
+                        elif event is h11.NEED_DATA:
+                            break
+                        else:
+                            done = True
+                            break
+
+                body = b"".join(body_parts)
                 content_length = len(body)
             else:
                 content_length = len(body)
@@ -354,8 +362,6 @@ class _ConnectionHandler:
             # Update headers if body was modified or chunked encoding was decoded
             new_body_len = len(scanned_body)
             if was_chunked or (new_body_len != content_length and content_length > 0):
-                import re
-
                 headers_text = headers_bytes.decode("latin-1")
                 if was_chunked:
                     # Remove Transfer-Encoding: chunked — body is now plain bytes
@@ -460,21 +466,61 @@ class _ConnectionHandler:
                     await client_writer.drain()
                     sent += len(chunk)
             elif "chunked" in transfer_encoding:
-                # Stream chunked data through until we see the terminal chunk
-                buf = resp_body_start
-                # Check if the terminal chunk is already in the initial data
-                if not (b"\r\n0\r\n\r\n" in buf or buf.startswith(b"0\r\n\r\n")):
+                # Use h11 to properly detect end of chunked response stream.
+                # h11 tracks chunk framing and emits EndOfMessage at the terminal chunk.
+                resp_conn = h11.Connection(our_role=h11.CLIENT)
+                # Put h11 in the correct state by telling it we "sent" a request
+                method_str = request_line.split(" ", 1)[0]
+                # Only include headers h11 needs for response parsing (host).
+                # Exclude body-framing headers so h11 doesn't expect request body data.
+                skip_headers = {"content-length", "transfer-encoding", "content-type"}
+                h11_headers = [
+                    (k.encode("latin-1"), v.encode("latin-1"))
+                    for k, v in req_headers.items()
+                    if k not in skip_headers
+                ]
+                if "host" not in req_headers:
+                    h11_headers.append((b"host", host.encode("latin-1")))
+                resp_conn.send(
+                    h11.Request(
+                        method=method_str.encode("latin-1"), target=b"/", headers=h11_headers
+                    )
+                )
+                resp_conn.send(h11.EndOfMessage())
+
+                # Feed the response data we already have (headers + any body start)
+                resp_conn.receive_data(resp_header_data)
+                resp_done = False
+                while True:
+                    ev = resp_conn.next_event()
+                    if isinstance(ev, (h11.Response, h11.InformationalResponse, h11.Data)):
+                        continue
+                    elif isinstance(ev, h11.EndOfMessage):
+                        resp_done = True
+                        break
+                    elif ev is h11.NEED_DATA:
+                        break
+                    else:
+                        break
+
+                while not resp_done:
+                    chunk = await upstream_reader.read(65536)
+                    if not chunk:
+                        return
+                    client_writer.write(chunk)
+                    await client_writer.drain()
+                    resp_conn.receive_data(chunk)
                     while True:
-                        chunk = await upstream_reader.read(65536)
-                        if not chunk:
-                            return
-                        client_writer.write(chunk)
-                        await client_writer.drain()
-                        # Check for end of chunked encoding (0\r\n\r\n)
-                        buf = (
-                            buf[-7:] + chunk
-                        )  # keep tail for boundary detection (pattern is 7 bytes)
-                        if b"\r\n0\r\n\r\n" in buf or buf.startswith(b"0\r\n\r\n"):
+                        ev = resp_conn.next_event()
+                        if isinstance(ev, h11.Data):
+                            continue
+                        elif isinstance(ev, h11.EndOfMessage):
+                            resp_done = True
+                            break
+                        elif ev is h11.NEED_DATA:
+                            break
+                        else:
+                            resp_done = True
                             break
             else:
                 # No content-length, no chunked — read until connection close
@@ -567,8 +613,6 @@ class _ConnectionHandler:
 
         # Update Content-Length if body was modified by scanning
         if len(scanned_body) != content_length and content_length > 0:
-            import re
-
             hdr_text = modified_headers.decode("latin-1")
             hdr_text = re.sub(
                 r"(?i)content-length:\s*\d+",

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -296,3 +296,162 @@ class TestBlockMode:
         finally:
             echo_server.close()
             await echo_server.wait_closed()
+
+
+async def _run_chunked_echo_https_server(ca: CertAuthority, host: str = "127.0.0.1"):
+    """HTTPS echo server that returns the request body as a chunked response."""
+    ssl_ctx = ca.get_domain_context(host)
+
+    async def handle(reader, writer):
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = await reader.read(4096)
+            if not chunk:
+                writer.close()
+                return
+            data += chunk
+
+        header_end = data.index(b"\r\n\r\n") + 4
+        body_start = data[header_end:]
+        headers_text = data[:header_end].decode("latin-1")
+        content_length = 0
+        for line in headers_text.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":", 1)[1].strip())
+                break
+
+        body = body_start
+        while len(body) < content_length:
+            chunk = await reader.read(4096)
+            if not chunk:
+                break
+            body += chunk
+
+        # Echo back using chunked transfer encoding
+        response_body = body if body else b"OK"
+        response_headers = (
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n"
+        )
+        writer.write(response_headers)
+        await writer.drain()
+
+        # Send body in two chunks
+        mid = len(response_body) // 2 or 1
+        for part in [response_body[:mid], response_body[mid:]]:
+            chunk_header = f"{len(part):x}\r\n".encode()
+            writer.write(chunk_header + part + b"\r\n")
+            await writer.drain()
+
+        # Terminal chunk
+        writer.write(b"0\r\n\r\n")
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handle, host, 0, ssl=ssl_ctx)
+    return server
+
+
+class TestChunkedEncoding:
+    async def test_chunked_request_body_decoded(self, ca, proxy_server):
+        """Chunked request body should be decoded and scanned for secrets."""
+        _, port = proxy_server
+
+        echo_server = await _run_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            # Send a chunked request with a secret embedded in chunk data
+            secret = b"REDACTED<aws-access-key:1a5d44a2dca1>"
+            chunk1 = b"data="
+            chunk2 = secret
+            chunked_body = (
+                f"{len(chunk1):x}\r\n".encode()
+                + chunk1
+                + b"\r\n"
+                + f"{len(chunk2):x}\r\n".encode()
+                + chunk2
+                + b"\r\n"
+                + b"0\r\n\r\n"
+            )
+            inner_request = (
+                b"POST /test HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/x-www-form-urlencoded\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n" + chunked_body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            # Secret should be redacted
+            assert b"REDACTED<aws-access-key:1a5d44a2dca1>" not in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+    async def test_chunked_response_relayed(self, ca, proxy_server):
+        """Chunked response from upstream should be streamed through to client."""
+        _, port = proxy_server
+
+        echo_server = await _run_chunked_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            body = b"hello chunked world"
+            inner_request = (
+                b"POST /test HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: text/plain\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            assert b"Transfer-Encoding: chunked" in inner_response
+            # Body is split across chunks, so check the terminal chunk was relayed
+            assert b"0\r\n\r\n" in inner_response
+            # Verify the body content is present (may span chunk boundaries)
+            assert b"hello chu" in inner_response
+            assert b"nked world" in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `_decode_chunked()` function and fragile `\r\n0\r\n\r\n` terminal chunk detection with h11's spec-compliant HTTP/1.1 state machine
- Request path uses h11 SERVER connection to incrementally decode chunked bodies before secret scanning
- Response path uses h11 CLIENT connection to properly detect chunked stream completion
- Add `h11>=0.14` as explicit dependency (was previously only a transitive dep via uvicorn)
- Add integration tests for chunked request body decoding and chunked response relay

## Test plan

- [x] All 61 existing tests pass
- [x] New test: chunked request body with embedded secret is decoded and redacted
- [x] New test: chunked response from upstream is streamed through to client
- [x] End-to-end test with `secretgate wrap -- curl` against a real HTTPS endpoint

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)