### PR TITLE
fix: send proper HTTP errors instead of silent EOF

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -243,6 +243,25 @@ class _ConnectionHandler:
         except (ConnectionResetError, BrokenPipeError, asyncio.CancelledError):
             pass
 
+    @staticmethod
+    async def _send_error(
+        writer: asyncio.StreamWriter, status: int, reason: str, body: str
+    ) -> None:
+        """Send an HTTP error response to the client."""
+        body_bytes = body.encode()
+        response = (
+            f"HTTP/1.1 {status} {reason}\r\n"
+            f"Content-Type: text/plain\r\n"
+            f"Content-Length: {len(body_bytes)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode() + body_bytes
+        try:
+            writer.write(response)
+            await writer.drain()
+        except (ConnectionResetError, BrokenPipeError, OSError):
+            pass  # client already gone
+
     async def _relay_http(
         self,
         client_reader: asyncio.StreamReader,
@@ -263,6 +282,13 @@ class _ConnectionHandler:
                     return
                 req_header_data += chunk
                 if len(req_header_data) > MAX_BUFFER_SIZE:
+                    logger.warning("forward_request_headers_too_large", host=host)
+                    await self._send_error(
+                        client_writer,
+                        413,
+                        "Request Entity Too Large",
+                        "Request headers exceed maximum buffer size",
+                    )
                     return
 
             # Split headers from any body data that was read
@@ -397,6 +423,12 @@ class _ConnectionHandler:
                     )
                 except Exception as exc:
                     logger.warning("forward_upstream_reconnect_failed", host=host, error=str(exc))
+                    await self._send_error(
+                        client_writer,
+                        502,
+                        "Bad Gateway",
+                        "Failed to reconnect to upstream server",
+                    )
                     return
                 upstream_writer.write(headers_bytes + scanned_body)
                 await upstream_writer.drain()
@@ -422,6 +454,12 @@ class _ConnectionHandler:
                                 ssl=_ssl,
                             )
                         except Exception:
+                            await self._send_error(
+                                client_writer,
+                                502,
+                                "Bad Gateway",
+                                "Failed to reconnect to upstream server",
+                            )
                             return
                         # Resend the request on the new connection
                         upstream_writer.write(headers_bytes + scanned_body)
@@ -429,9 +467,23 @@ class _ConnectionHandler:
                         resp_header_data = b""
                         reconnected = True
                         continue
+                    logger.warning("forward_upstream_eof", host=host)
+                    await self._send_error(
+                        client_writer,
+                        502,
+                        "Bad Gateway",
+                        "Upstream server closed connection without responding",
+                    )
                     return
                 resp_header_data += chunk
                 if len(resp_header_data) > MAX_BUFFER_SIZE:
+                    logger.warning("forward_response_headers_too_large", host=host)
+                    await self._send_error(
+                        client_writer,
+                        502,
+                        "Bad Gateway",
+                        "Upstream response headers exceed maximum buffer size",
+                    )
                     return
 
             resp_header_end = resp_header_data.index(b"\r\n\r\n") + 4

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -455,3 +455,55 @@ class TestChunkedEncoding:
         finally:
             echo_server.close()
             await echo_server.wait_closed()
+
+
+class TestErrorResponses:
+    async def test_502_when_upstream_drops_connection(self, ca, proxy_server):
+        """Proxy should send 502 instead of EOF when upstream drops the connection."""
+        _, port = proxy_server
+
+        # Start a server that accepts the TLS connection then immediately closes
+        ssl_ctx = ca.get_domain_context("127.0.0.1")
+
+        async def handle(reader, writer):
+            # Read request headers then close without responding
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                data += chunk
+            writer.close()
+            await writer.wait_closed()
+
+        drop_server = await asyncio.start_server(handle, "127.0.0.1", 0, ssl=ssl_ctx)
+        drop_port = drop_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{drop_port} HTTP/1.1\r\nHost: 127.0.0.1:{drop_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx_client = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx_client.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx_client, server_hostname="127.0.0.1")
+
+            inner_request = b"GET /test HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            # Should get a proper 502 error, not EOF
+            assert b"502 Bad Gateway" in inner_response
+
+            writer.close()
+        finally:
+            drop_server.close()
+            await drop_server.wait_closed()


### PR DESCRIPTION
## Summary

- The forward proxy had several code paths where it silently closed the client connection without sending any HTTP response — clients saw an unexpected EOF instead of a meaningful error
- Add `_send_error()` helper for consistent error responses
- Send 502 Bad Gateway when upstream closes without responding (most likely cause of `gh release create` EOF)
- Send 502 when upstream reconnection fails (on both write and read paths)
- Send 413 when request headers exceed buffer size
- Send 502 when response headers exceed buffer size
- Add warning-level logs for all error paths

## Test plan

- [x] All 62 tests pass (61 existing + 1 new)
- [x] New test: proxy sends 502 when upstream drops connection without responding
- [x] End-to-end test with `gh release create` through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)