### PR TITLE
chore: add PyPI publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,11 @@ ruff check src/ tests/
 
 ## Publishing
 
-Package is on PyPI as `secretgate`. To release a new version:
+Package is on PyPI as `secretgate`. Releases are automated via GitHub Actions trusted publishing (OIDC, no tokens):
+
 1. Bump version in `pyproject.toml`
-2. `python -m build`
-3. `twine upload dist/*` (or use GitHub Actions trusted publishing)
+2. Create a GitHub Release with tag `vX.Y.Z`
+3. The `publish.yml` workflow builds and uploads to PyPI automatically
 
 ## Forward proxy
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,14 @@ pre-commit install
 This enables ruff lint/format, trailing whitespace fixes, and secretgate's own
 secret scanner on staged files.
 
+## Releasing
+
+Releases are published to [PyPI](https://pypi.org/project/secretgate/) automatically via GitHub Actions using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (no API tokens needed).
+
+1. Bump the version in `pyproject.toml`
+2. Create a [GitHub Release](https://github.com/secretgate/secretgate/releases/new) with tag `vX.Y.Z`
+3. The `publish.yml` workflow builds and uploads to PyPI
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` that builds and publishes to PyPI on GitHub Release using trusted publishing (OIDC)
- Update CLAUDE.md and README.md with the new release process

## Test plan
- [x] Create a GitHub Release with tag `v0.3.0` and verify the workflow runs and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)