### PR TITLE
fix: skip scanning on auth/token endpoints to prevent OAuth breakage

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -21,6 +21,21 @@ logger = structlog.get_logger()
 
 MAX_BUFFER_SIZE = 10 * 1024 * 1024  # 10MB
 
+# Paths that should never be scanned — auth/token endpoints contain
+# credentials (JWTs, refresh tokens) that would be redacted and break
+# authentication flows like OAuth token refresh.
+_AUTH_PATH_PATTERNS = re.compile(
+    r"(?:"
+    r"/oauth(?:/|$)"  # /oauth/ or /oauth at end
+    r"|/auth(?:/|$)"  # /auth/ or /auth at end
+    r"|/token(?:/|$|\?)"  # /token, /token/, /token?...
+    r"|/authorize(?:/|$|\?)"  # /authorize, /authorize/, /authorize?...
+    r"|/\.well-known/"  # /.well-known/openid-configuration etc.
+    r"|/login"  # /login endpoints
+    r")",
+    re.IGNORECASE,
+)
+
 
 class ForwardProxyServer:
     """Wraps asyncio.Server with active task tracking for clean shutdown."""
@@ -107,6 +122,11 @@ class _ConnectionHandler:
         self._scanner = scanner
         self._passthrough = passthrough_domains
         self._upstream_ssl = upstream_ssl
+
+    @staticmethod
+    def _is_auth_path(path: str) -> bool:
+        """Return True if the request path is an auth/token endpoint that should skip scanning."""
+        return bool(_AUTH_PATH_PATTERNS.search(path))
 
     async def run(self) -> None:
         """Read the initial request and dispatch."""
@@ -369,10 +389,15 @@ class _ConnectionHandler:
             else:
                 content_length = len(body)
 
-            # Scan outbound request body
+            # Scan outbound request body (skip auth endpoints to avoid
+            # redacting OAuth tokens / refresh tokens)
+            req_path = request_line.split(" ", 2)[1] if request_line else ""
             content_type = req_headers.get("content-type", "application/octet-stream")
             scanned_body = body
-            if body and content_length > 0:
+            skip_scan = self._is_auth_path(req_path)
+            if skip_scan:
+                logger.debug("forward_skip_auth_path", host=host, path=req_path)
+            if body and content_length > 0 and not skip_scan:
                 try:
                     scanned_body, alerts = self._scanner.scan_body(body, content_type)
                     for alert in alerts:
@@ -649,10 +674,14 @@ class _ConnectionHandler:
                 break
             body += chunk
 
-        # Scan body
+        # Scan body (skip auth endpoints to avoid redacting OAuth tokens)
+        req_path = parsed.path or "/"
         content_type = headers.get("content-type", "application/octet-stream")
         scanned_body = body
-        if body and content_length > 0:
+        skip_scan = self._is_auth_path(req_path)
+        if skip_scan:
+            logger.debug("forward_skip_auth_path", host=host, path=req_path)
+        if body and content_length > 0 and not skip_scan:
             try:
                 scanned_body, alerts = self._scanner.scan_body(body, content_type)
                 for alert in alerts:

--- a/src/secretgate/proxy.py
+++ b/src/secretgate/proxy.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from secretgate.config import ProviderConfig
+from secretgate.forward import _AUTH_PATH_PATTERNS
 from secretgate.pipeline import Pipeline, PipelineContext
 
 if TYPE_CHECKING:
@@ -43,9 +44,11 @@ def create_provider_router(
         headers.pop("host", None)
         headers.pop("content-length", None)
 
-        # For non-JSON or GET requests, pass through directly
-        if request.method == "GET" or "application/json" not in request.headers.get(
-            "content-type", ""
+        # For non-JSON, GET, or auth/token endpoints, pass through directly
+        if (
+            request.method == "GET"
+            or "application/json" not in request.headers.get("content-type", "")
+            or _AUTH_PATH_PATTERNS.search(f"/{path}")
         ):
             return await _passthrough(request, upstream_url, headers, state.http_client)
 

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -8,7 +8,7 @@ import ssl
 import pytest
 
 from secretgate.certs import CertAuthority
-from secretgate.forward import start_forward_proxy
+from secretgate.forward import _ConnectionHandler, start_forward_proxy
 from secretgate.scan import TextScanner
 from secretgate.secrets.scanner import SecretScanner
 
@@ -450,6 +450,119 @@ class TestChunkedEncoding:
             # Verify the body content is present (may span chunk boundaries)
             assert b"hello chu" in inner_response
             assert b"nked world" in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+
+class TestAuthPathSkip:
+    """Auth/token endpoints should skip scanning to avoid redacting OAuth tokens."""
+
+    def test_is_auth_path_matches(self):
+        assert _ConnectionHandler._is_auth_path("/oauth/token") is True
+        assert _ConnectionHandler._is_auth_path("/v1/oauth/token") is True
+        assert _ConnectionHandler._is_auth_path("/auth/refresh") is True
+        assert _ConnectionHandler._is_auth_path("/v1/auth/callback") is True
+        assert _ConnectionHandler._is_auth_path("/token") is True
+        assert _ConnectionHandler._is_auth_path("/api/token") is True
+        assert _ConnectionHandler._is_auth_path("/authorize") is True
+        assert _ConnectionHandler._is_auth_path("/.well-known/openid-configuration") is True
+        assert _ConnectionHandler._is_auth_path("/login") is True
+
+    def test_is_auth_path_no_match(self):
+        assert _ConnectionHandler._is_auth_path("/v1/messages") is False
+        assert _ConnectionHandler._is_auth_path("/v1/chat/completions") is False
+        assert _ConnectionHandler._is_auth_path("/v1/embeddings") is False
+        assert _ConnectionHandler._is_auth_path("/health") is False
+        assert _ConnectionHandler._is_auth_path("/") is False
+
+    async def test_auth_path_not_scanned_in_tunnel(self, ca, proxy_server):
+        """Secrets in auth endpoint requests should pass through unredacted."""
+        _, port = proxy_server
+
+        echo_server = await _run_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            # Send a request to an auth endpoint with a JWT (would normally be redacted)
+            jwt = b"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature_here"
+            body = b'{"refresh_token":"' + jwt + b'"}'
+            inner_request = (
+                b"POST /oauth/token HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            # The JWT should NOT be redacted — auth paths skip scanning
+            assert jwt in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+    async def test_non_auth_path_still_scanned(self, ca, proxy_server):
+        """Secrets in regular API requests should still be redacted."""
+        _, port = proxy_server
+
+        echo_server = await _run_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            # Send a request to a regular endpoint with a secret
+            body = b"data=AKIAIOSFODNN7EXAMPLE"
+            inner_request = (
+                b"POST /v1/messages HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/x-www-form-urlencoded\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            # The AWS key should still be redacted on non-auth paths
+            assert b"AKIAIOSFODNN7EXAMPLE" not in inner_response
 
             writer.close()
         finally:


### PR DESCRIPTION
## Summary

- The JWT regex pattern in `signatures.yaml` matches OAuth tokens (`eyJ...`), causing the proxy to redact refresh tokens in OAuth token refresh requests — silently breaking the refresh flow and leading to 401 errors after token expiry (e.g. overnight)
- Skip body scanning for auth-related request paths (`/oauth/`, `/auth/`, `/token`, `/authorize`, `/.well-known/`, `/login`) in both the forward proxy and reverse proxy
- Adds 4 tests: path matching (positive + negative), auth path passthrough in MITM tunnel, and confirmation that non-auth paths are still scanned

## Test plan

- [x] All 66 tests pass (62 existing + 4 new)
- [x] `ruff check` and `ruff format` pass
- [x] Manual: run `secretgate wrap -- claude` with OAuth, verify token refresh works overnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)