### PR TITLE
feat: content-block-aware scanning for Anthropic API

### DIFF
--- a/src/secretgate/steps.py
+++ b/src/secretgate/steps.py
@@ -21,7 +21,7 @@ class SecretRedactionStep(PipelineStep):
         self._mode = mode  # "redact", "block", or "audit"
 
     async def process_request(self, body: dict, ctx: PipelineContext) -> dict | None:
-        # First, scan all message text to detect secrets (without mutating)
+        # First, scan scannable text to detect secrets (without mutating)
         all_text = self._extract_text(body)
         matches = self._scanner.scan(all_text)
 
@@ -47,16 +47,20 @@ class SecretRedactionStep(PipelineStep):
 
         # Redact mode: replace secrets with placeholders
         redactor = SecretRedactor(self._scanner)
-        messages = body.get("messages", [])
 
-        for msg in messages:
+        # Redact the system field
+        _redact_system(body, redactor)
+
+        # Redact only scannable message content (user text + tool_result)
+        for msg in body.get("messages", []):
+            role = msg.get("role", "")
+            if role != "user":
+                continue
             content = msg.get("content")
             if isinstance(content, str):
                 msg["content"] = redactor.redact(content)
             elif isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        block["text"] = redactor.redact(block.get("text", ""))
+                _redact_user_blocks(content, redactor)
 
         ctx.metadata["redactor"] = redactor
         logger.info("secrets_redacted", count=redactor.count)
@@ -64,16 +68,46 @@ class SecretRedactionStep(PipelineStep):
 
     @staticmethod
     def _extract_text(body: dict) -> str:
-        """Extract all text content from messages for scanning."""
+        """Extract scannable text from the request body.
+
+        Content-block-aware extraction:
+        - system field: always scanned (user-supplied)
+        - user text blocks: scanned (most likely leak vector)
+        - user tool_result blocks: scanned (tool output may contain secrets)
+        - assistant messages: skipped (model-generated)
+        - tool_use blocks: skipped (structured function calls)
+        - thinking blocks: skipped (model-internal, cryptographic signatures)
+        - image blocks: skipped (binary data)
+        """
         parts: list[str] = []
+
+        # System field — always user-supplied
+        system = body.get("system")
+        if isinstance(system, str):
+            parts.append(system)
+        elif isinstance(system, list):
+            for block in system:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+
         for msg in body.get("messages", []):
+            role = msg.get("role", "")
+            # Skip assistant messages entirely — model-generated content
+            if role != "user":
+                continue
+
             content = msg.get("content")
             if isinstance(content, str):
                 parts.append(content)
             elif isinstance(content, list):
                 for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
+                    if not isinstance(block, dict):
+                        continue
+                    block_type = block.get("type", "")
+                    if block_type == "text":
                         parts.append(block.get("text", ""))
+                    elif block_type == "tool_result":
+                        _extract_tool_result_text(block, parts)
         return "\n".join(parts)
 
     async def process_response(self, body: dict, ctx: PipelineContext) -> dict:
@@ -149,6 +183,46 @@ def _unredact_dict(d: dict, redactor: SecretRedactor) -> None:
             d[key] = redactor.unredact(v)
         else:
             _unredact_value(v, redactor)
+
+
+def _extract_tool_result_text(block: dict, parts: list[str]) -> None:
+    """Extract scannable text from a tool_result content block."""
+    content = block.get("content")
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for sub in content:
+            if isinstance(sub, dict) and sub.get("type") == "text":
+                parts.append(sub.get("text", ""))
+
+
+def _redact_system(body: dict, redactor: SecretRedactor) -> None:
+    """Redact secrets in the system field."""
+    system = body.get("system")
+    if isinstance(system, str):
+        body["system"] = redactor.redact(system)
+    elif isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                block["text"] = redactor.redact(block.get("text", ""))
+
+
+def _redact_user_blocks(blocks: list, redactor: SecretRedactor) -> None:
+    """Redact secrets in user message content blocks (text + tool_result)."""
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type", "")
+        if block_type == "text":
+            block["text"] = redactor.redact(block.get("text", ""))
+        elif block_type == "tool_result":
+            content = block.get("content")
+            if isinstance(content, str):
+                block["content"] = redactor.redact(content)
+            elif isinstance(content, list):
+                for sub in content:
+                    if isinstance(sub, dict) and sub.get("type") == "text":
+                        sub["text"] = redactor.redact(sub.get("text", ""))
 
 
 class AuditLogStep(PipelineStep):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -185,6 +185,251 @@ async def test_thinking_sse_events_not_unredacted():
     assert secret in text_line
 
 
+# ---------------------------------------------------------------------------
+# Content-block-aware scanning tests
+# ---------------------------------------------------------------------------
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+@pytest.mark.asyncio
+async def test_skips_assistant_text_blocks():
+    """Assistant text blocks should not be scanned — model-generated content."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {"role": "assistant", "content": f"Here is the key: {AWS_KEY}"},
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found == 0
+    # Content should be unchanged — not scanned, not redacted
+    assert result["messages"][0]["content"] == f"Here is the key: {AWS_KEY}"
+
+
+@pytest.mark.asyncio
+async def test_skips_tool_use_blocks():
+    """tool_use blocks (assistant) should not be scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "write_file",
+                        "input": {"path": "/tmp/test", "content": AWS_KEY},
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found == 0
+
+
+@pytest.mark.asyncio
+async def test_skips_thinking_blocks():
+    """Thinking blocks should not be scanned (model-internal + signatures)."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "thinking", "thinking": f"key: {AWS_KEY}", "signature": "sig123"},
+                    {"type": "text", "text": "hello"},
+                ],
+            }
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found == 0
+    # Thinking block content unchanged
+    assert result["messages"][0]["content"][0]["thinking"] == f"key: {AWS_KEY}"
+
+
+@pytest.mark.asyncio
+async def test_scans_tool_result_string_content():
+    """tool_result blocks with string content should be scanned and redacted."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01",
+                        "content": f"Command output: {AWS_KEY}",
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found >= 1
+    assert AWS_KEY not in result["messages"][0]["content"][0]["content"]
+    assert "REDACTED<" in result["messages"][0]["content"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_scans_tool_result_list_content():
+    """tool_result blocks with list content (text sub-blocks) should be scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01",
+                        "content": [
+                            {"type": "text", "text": f"File contains: {AWS_KEY}"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found >= 1
+    sub_block = result["messages"][0]["content"][0]["content"][0]
+    assert AWS_KEY not in sub_block["text"]
+
+
+@pytest.mark.asyncio
+async def test_scans_system_string():
+    """The system field (string form) should always be scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "system": f"System prompt with key: {AWS_KEY}",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found >= 1
+    assert AWS_KEY not in result["system"]
+    assert "REDACTED<" in result["system"]
+
+
+@pytest.mark.asyncio
+async def test_scans_system_content_blocks():
+    """The system field (content block list form) should always be scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "system": [{"type": "text", "text": f"Config: {AWS_KEY}"}],
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found >= 1
+    assert AWS_KEY not in result["system"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_skips_image_blocks():
+    """Image blocks should not be scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/png", "data": AWS_KEY},
+                    },
+                ],
+            }
+        ]
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found == 0
+
+
+@pytest.mark.asyncio
+async def test_mixed_conversation_selective_scanning():
+    """Full conversation with mixed roles/block types — only user content scanned."""
+    scanner = SecretScanner()
+    step = SecretRedactionStep(scanner, mode="redact")
+    ctx = PipelineContext()
+
+    body = {
+        "system": "You are a helpful assistant.",
+        "messages": [
+            # Earlier user turn (should be scanned)
+            {"role": "user", "content": "What is 2+2?"},
+            # Assistant reply (should NOT be scanned)
+            {"role": "assistant", "content": f"The answer is 4. Key: {AWS_KEY}"},
+            # User turn with tool result containing a secret (should be scanned)
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_01",
+                        "content": f"export AWS_ACCESS_KEY_ID={AWS_KEY}",
+                    },
+                    {"type": "text", "text": "What does this file contain?"},
+                ],
+            },
+        ],
+    }
+
+    result = await step.process_request(body, ctx)
+    assert result is not None
+    assert ctx.secrets_found >= 1
+
+    # Assistant message should be untouched (not scanned, not redacted)
+    assert AWS_KEY in result["messages"][1]["content"]
+
+    # User tool_result should be redacted
+    assert AWS_KEY not in result["messages"][2]["content"][0]["content"]
+    assert "REDACTED<" in result["messages"][2]["content"][0]["content"]
+
+
 def test_is_thinking_sse_data():
     assert _is_thinking_sse_data(
         json.dumps(


### PR DESCRIPTION
## Summary

- **Content-block-aware extraction**: `_extract_text()` now distinguishes between Anthropic content block types instead of scanning everything as flat text
- **Selective redaction**: Only user-supplied content is redacted; assistant messages pass through untouched
- **System field scanning**: The `system` field (string or content block list) is now scanned and redacted

| Block type | Role | Behavior |
|---|---|---|
| `text` | user | Full scan + redact |
| `tool_result` | user | Full scan + redact (string and list content) |
| `text` | assistant | Skip |
| `tool_use` | assistant | Skip |
| `thinking` | any | Skip |
| `image` | any | Skip |

Closes #19

## Test plan

- [x] All 90 tests pass (81 existing + 9 new)
- [x] New tests cover: assistant skip, tool_use skip, thinking skip, tool_result string/list scanning, system string/block scanning, image skip, mixed conversation selective scanning
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)