### PR TITLE
feat: enhance scan CLI (directory walk, --json-output, --staged) + WebSocket upgrade passthrough

### DIFF
--- a/docs/pre-commit-hook.md
+++ b/docs/pre-commit-hook.md
@@ -1,0 +1,80 @@
+# Pre-commit Hook Integration
+
+secretgate can be used as a pre-commit hook to catch secrets before they
+reach git history. There are two approaches:
+
+## 1. Using `secretgate scan --staged`
+
+The simplest approach — scans only the staged diff:
+
+```bash
+# .git/hooks/pre-commit
+#!/bin/sh
+secretgate scan --staged --no-entropy
+```
+
+Or with a shell script in your repo:
+
+```bash
+# scripts/pre-commit.sh
+#!/bin/sh
+set -e
+echo "Scanning staged changes for secrets..."
+secretgate scan --staged --no-entropy
+```
+
+## 2. Using `.pre-commit-config.yaml`
+
+If you use the [pre-commit](https://pre-commit.com/) framework:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: secretgate
+        name: secretgate secret scan
+        entry: secretgate scan --no-entropy
+        language: system
+        types: [text]
+```
+
+## 3. CI/CD Integration
+
+For CI pipelines, use `--json-output` for machine-readable results:
+
+```yaml
+# .github/workflows/ci.yml
+- name: Scan for secrets
+  run: |
+    pip install secretgate
+    secretgate scan --json-output src/ tests/ > scan-results.json || {
+      echo "::error::Secrets detected in codebase"
+      cat scan-results.json
+      exit 1
+    }
+```
+
+## Directory Scanning
+
+`secretgate scan` supports directory arguments and will walk them
+recursively, automatically skipping:
+
+- Binary files (`.png`, `.jpg`, `.zip`, `.pdf`, etc.)
+- Hidden directories (`.git`, `.venv`, etc.)
+- Build artifacts (`node_modules`, `__pycache__`, `dist`, etc.)
+
+```bash
+# Scan entire project
+secretgate scan src/ tests/ docs/
+
+# Scan everything
+secretgate scan .
+```
+
+## Tips
+
+- Use `--no-entropy` to reduce false positives in pre-commit hooks
+  (entropy detection can flag random-looking code)
+- Use `--no-known-values` if env-var harvesting is too noisy locally
+- The `--json-output` flag is useful for CI/CD integration and log parsing

--- a/src/secretgate/cli.py
+++ b/src/secretgate/cli.py
@@ -133,11 +133,30 @@ def serve(
     is_flag=True,
     help="Disable known-value secret scanning (env var / file harvesting)",
 )
+@click.option(
+    "--json-output",
+    "json_output",
+    is_flag=True,
+    help="Output results as JSON (useful for CI/CD pipelines)",
+)
+@click.option(
+    "--staged",
+    is_flag=True,
+    help="Scan only git staged changes (for pre-commit hooks)",
+)
 @click.argument("files", nargs=-1, type=click.Path(exists=True))
-def scan(use_detect_secrets: bool, no_entropy: bool, no_known_values: bool, files: tuple[str, ...]):
+def scan(
+    use_detect_secrets: bool,
+    no_entropy: bool,
+    no_known_values: bool,
+    json_output: bool,
+    staged: bool,
+    files: tuple[str, ...],
+):
     """Scan files or stdin for secrets.
 
     Pass file paths as arguments, or pipe text via stdin.
+    Directories are walked recursively (binary and hidden files are skipped).
 
     \b
     Examples:
@@ -147,6 +166,7 @@ def scan(use_detect_secrets: bool, no_entropy: bool, no_known_values: bool, file
         git diff --cached | secretgate scan
     """
     import sys
+
     from secretgate.secrets.scanner import SecretScanner
 
     scanner = SecretScanner(
@@ -155,32 +175,148 @@ def scan(use_detect_secrets: bool, no_entropy: bool, no_known_values: bool, file
         enable_known_values=not no_known_values,
     )
     total_matches = []
+    files_scanned = 0
 
-    if files:
-        for filepath in files:
-            with open(filepath) as f:
-                text = f.read()
-            matches = scanner.scan(text)
-            for m in matches:
-                preview = m.value[:8] + "..." if len(m.value) > 8 else m.value
-                click.echo(
-                    f"  {filepath}:{m.line_number}: [{m.service}] {m.pattern_name} — {preview}"
+    if staged:
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--cached", "--diff-filter=ACMR", "--name-only"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            staged_files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            click.echo("Error: not a git repository or git not available", err=True)
+            sys.exit(2)
+
+        for filepath in staged_files:
+            try:
+                # Read the staged version (not the working copy)
+                staged_content = subprocess.run(
+                    ["git", "show", f":{filepath}"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
                 )
+                text = staged_content.stdout
+            except (subprocess.CalledProcessError, UnicodeDecodeError):
+                continue
+            files_scanned += 1
+            matches = scanner.scan(text)
+            if not json_output:
+                for m in matches:
+                    preview = m.value[:8] + "..." if len(m.value) > 8 else m.value
+                    click.echo(
+                        f"  {filepath}:{m.line_number}: [{m.service}] {m.pattern_name} — {preview}"
+                    )
+            total_matches.extend(matches)
+    elif files:
+        resolved_files = _resolve_file_args(files)
+        for filepath in resolved_files:
+            try:
+                with open(filepath) as f:
+                    text = f.read()
+            except (UnicodeDecodeError, OSError):
+                continue  # skip binary or unreadable files
+            files_scanned += 1
+            matches = scanner.scan(text)
+            if not json_output:
+                for m in matches:
+                    preview = m.value[:8] + "..." if len(m.value) > 8 else m.value
+                    click.echo(
+                        f"  {filepath}:{m.line_number}: [{m.service}] {m.pattern_name} — {preview}"
+                    )
             total_matches.extend(matches)
     else:
         text = sys.stdin.read()
+        files_scanned = 1
         matches = scanner.scan(text)
-        for m in matches:
-            preview = m.value[:8] + "..." if len(m.value) > 8 else m.value
-            click.echo(f"  Line {m.line_number}: [{m.service}] {m.pattern_name} — {preview}")
+        if not json_output:
+            for m in matches:
+                preview = m.value[:8] + "..." if len(m.value) > 8 else m.value
+                click.echo(f"  Line {m.line_number}: [{m.service}] {m.pattern_name} — {preview}")
         total_matches.extend(matches)
 
-    if not total_matches:
-        click.echo("No secrets found.")
+    if json_output:
+        import json
+
+        results = []
+        for m in total_matches:
+            results.append({
+                "service": m.service,
+                "pattern": m.pattern_name,
+                "line": m.line_number,
+                "preview": m.value[:8] + "..." if len(m.value) > 8 else m.value,
+            })
+        click.echo(json.dumps({
+            "secrets_found": len(total_matches),
+            "files_scanned": files_scanned,
+            "results": results,
+        }, indent=2))
+        if total_matches:
+            sys.exit(1)
         return
 
-    click.echo(f"\n{len(total_matches)} secret(s) found.")
+    if not total_matches:
+        summary = f"No secrets found ({files_scanned} file(s) scanned)."
+        click.echo(summary)
+        return
+
+    click.echo(f"\n{len(total_matches)} secret(s) found in {files_scanned} file(s).")
     sys.exit(1)
+
+
+# File extensions to skip when walking directories (binary/irrelevant files)
+_SKIP_EXTENSIONS = frozenset({
+    ".pyc", ".pyo", ".so", ".dylib", ".dll", ".exe",
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".bmp", ".webp", ".svg",
+    ".woff", ".woff2", ".ttf", ".eot",
+    ".zip", ".tar", ".gz", ".bz2", ".xz", ".7z",
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx",
+    ".db", ".sqlite", ".sqlite3",
+    ".lock",
+})
+
+# Directory names to skip when walking
+_SKIP_DIRS = frozenset({
+    ".git", ".hg", ".svn", "__pycache__", "node_modules",
+    ".venv", "venv", ".tox", ".eggs", ".mypy_cache",
+    ".ruff_cache", ".pytest_cache", "dist", "build",
+    ".next", ".nuxt",
+})
+
+
+def _resolve_file_args(paths: tuple[str, ...]) -> list[str]:
+    """Expand directories into individual file paths, skip binary/hidden files."""
+    from pathlib import Path as _Path
+
+    result: list[str] = []
+    for p in paths:
+        path = _Path(p)
+        if path.is_file():
+            result.append(str(path))
+        elif path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if not child.is_file():
+                    continue
+                # Skip hidden files
+                if any(part.startswith(".") and part not in (".env",) for part in child.parts):
+                    if child.parts != path.parts:  # don't skip the root arg itself
+                        # Only skip if a hidden *directory* is in the path
+                        rel = child.relative_to(path)
+                        if any(part.startswith(".") and part not in (".env",) for part in rel.parts[:-1]):
+                            continue
+                # Skip binary extensions
+                if child.suffix.lower() in _SKIP_EXTENSIONS:
+                    continue
+                # Skip known dirs (already handled by rglob but double-check)
+                if any(part in _SKIP_DIRS for part in child.parts):
+                    continue
+                result.append(str(child))
+    return result
 
 
 def _find_available_port(preferred: int, max_attempts: int = 20) -> int:

--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -408,6 +408,22 @@ class _ConnectionHandler:
                 await self._send_error(client_writer, 400, "Bad Request", "Malformed HTTP request")
                 return
 
+            # Detect WebSocket upgrade — forward headers then switch to raw pipe
+            if (
+                req_headers.get("upgrade", "").lower() == "websocket"
+                and "upgrade" in req_headers.get("connection", "").lower()
+            ):
+                logger.info("websocket_upgrade_detected", host=host)
+                upstream_writer.write(req_header_data)
+                await upstream_writer.drain()
+                # Relay the 101 response + all subsequent frames as raw bytes
+                await asyncio.gather(
+                    self._pipe(upstream_reader, client_writer),
+                    self._pipe(client_reader, upstream_writer),
+                    return_exceptions=True,
+                )
+                return
+
             # Read the request body
             content_length_str = req_headers.get("content-length")
             req_transfer = req_headers.get("transfer-encoding", "").lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,80 @@ class TestServeCommand:
         assert "--mode" in result.output
         assert "--forward-proxy-port" in result.output
         assert "redact" in result.output
+
+
+class TestScanDirectoryWalk:
+    def test_scan_directory(self, tmp_path):
+        """Scan a directory recursively."""
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / "clean.py").write_text("x = 1\n")
+        (sub / "dirty.env").write_text("AWS_KEY=AKIAIOSFODNN7EXAMPLE\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "secret(s) found" in result.output
+
+    def test_scan_directory_skips_binary(self, tmp_path):
+        """Binary extensions like .png should be skipped without error."""
+        (tmp_path / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        (tmp_path / "clean.txt").write_text("Hello\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output
+
+    def test_scan_directory_skips_git(self, tmp_path):
+        """The .git directory should be skipped."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("AWS_KEY=AKIAIOSFODNN7EXAMPLE\n")
+        (tmp_path / "clean.txt").write_text("Hello\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0
+
+    def test_scan_empty_directory(self, tmp_path):
+        """Empty directory should report zero files."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output
+
+
+class TestScanJsonOutput:
+    def test_json_output_clean(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["scan", "--json-output"], input="just normal text\n"
+        )
+        assert result.exit_code == 0
+        import json
+        data = json.loads(result.output)
+        assert data["secrets_found"] == 0
+        assert data["files_scanned"] == 1
+
+    def test_json_output_with_secrets(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["scan", "--json-output"],
+            input="AWS_KEY=AKIAIOSFODNN7EXAMPLE\n",
+        )
+        assert result.exit_code == 1
+        import json
+        data = json.loads(result.output)
+        assert data["secrets_found"] >= 1
+        assert len(data["results"]) >= 1
+        assert "service" in data["results"][0]
+        assert "pattern" in data["results"][0]
+
+    def test_json_output_file(self, tmp_path):
+        secret_file = tmp_path / "test.env"
+        secret_file.write_text("GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", "--json-output", str(secret_file)])
+        assert result.exit_code == 1
+        import json
+        data = json.loads(result.output)
+        assert data["secrets_found"] >= 1


### PR DESCRIPTION
## Summary

### Scan CLI improvements
- **Directory walking**: `secretgate scan src/` now recursively walks directories, skipping binary files (.png, .zip, .pdf, etc.), hidden directories (.git, .venv), and build artifacts (node_modules, __pycache__, dist)
- **`--json-output` flag**: Machine-readable JSON output for CI/CD pipelines — includes `secrets_found`, `files_scanned`, and per-match `service`/`pattern`/`line`/`preview`
- **`--staged` flag**: Scans only git staged changes by reading `git show :file` — perfect for pre-commit hooks
- Summary now shows file count: *"3 secret(s) found in 12 file(s)."*

### Forward proxy: WebSocket upgrade passthrough
Addresses #9 (option 1): detects `Connection: Upgrade` + `Upgrade: websocket` in the HTTP relay, forwards the request to upstream, and switches to raw bidirectional pipe. No scanning of WebSocket frames (binary protocol), but clean handling instead of unpredictable behavior.

### Docs
- New `docs/pre-commit-hook.md` with examples for shell hooks, pre-commit framework, and GitHub Actions CI integration

### Tests
- 7 new tests covering directory walking, binary file skipping, .git directory exclusion, empty directories, JSON output (clean + dirty), and file-based JSON output

All 271 tests pass, ruff clean.