### PR TITLE
fix: version sync, directory scanning in CLI, config env overrides

### DIFF
--- a/src/secretgate/__init__.py
+++ b/src/secretgate/__init__.py
@@ -1,3 +1,3 @@
 """secretgate — lean security proxy for AI coding tools."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/secretgate/cli.py
+++ b/src/secretgate/cli.py
@@ -116,6 +116,25 @@ def serve(
     uvicorn.run(app, host=cfg.host, port=cfg.port, log_level=log_level)
 
 
+def _resolve_paths(paths: list[str]) -> list[str]:
+    """Expand directories into individual file paths for scanning."""
+    import os
+
+    result: list[str] = []
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _dirs, filenames in os.walk(p):
+                # Skip hidden directories (e.g. .git, .venv)
+                _dirs[:] = [d for d in _dirs if not d.startswith(".")]
+                for fname in sorted(filenames):
+                    if fname.startswith("."):
+                        continue
+                    result.append(os.path.join(root, fname))
+        else:
+            result.append(p)
+    return result
+
+
 @main.command()
 @click.option(
     "--detect-secrets",
@@ -157,9 +176,13 @@ def scan(use_detect_secrets: bool, no_entropy: bool, no_known_values: bool, file
     total_matches = []
 
     if files:
-        for filepath in files:
-            with open(filepath) as f:
-                text = f.read()
+        resolved_files = _resolve_paths(list(files))
+        for filepath in resolved_files:
+            try:
+                with open(filepath) as f:
+                    text = f.read()
+            except (OSError, UnicodeDecodeError):
+                continue  # skip binary/unreadable files
             matches = scanner.scan(text)
             for m in matches:
                 preview = m.value[:8] + "..." if len(m.value) > 8 else m.value

--- a/src/secretgate/config.py
+++ b/src/secretgate/config.py
@@ -136,6 +136,10 @@ class Config:
             cfg.forward_proxy_port = int(fpp)
         if certs := os.environ.get("SECRETGATE_CERTS_DIR"):
             cfg.certs_dir = Path(certs)
+        if log_fmt := os.environ.get("SECRETGATE_LOG_FORMAT"):
+            cfg.log_format = log_fmt
+        if audit := os.environ.get("SECRETGATE_AUDIT_LOG"):
+            cfg.audit_log = Path(audit)
 
         # Set up default providers if none configured
         if not cfg.providers:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,41 @@ class TestServeCommand:
         assert "--mode" in result.output
         assert "--forward-proxy-port" in result.output
         assert "redact" in result.output
+
+
+class TestScanDirectory:
+    def test_scan_directory_with_secrets(self, tmp_path):
+        """scan should recurse into directories."""
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / "secrets.txt").write_text("MY_KEY=AKIAIOSFODNN7EXAMPLE\n")
+        (sub / "clean.txt").write_text("nothing here\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "secret(s) found" in result.output
+        assert "subdir" in result.output
+
+    def test_scan_directory_clean(self, tmp_path):
+        (tmp_path / "clean.txt").write_text("Hello world\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output
+
+    def test_scan_skips_hidden_dirs(self, tmp_path):
+        hidden = tmp_path / ".hidden"
+        hidden.mkdir()
+        (hidden / "secret.txt").write_text("MY_KEY=AKIAIOSFODNN7EXAMPLE\n")
+        (tmp_path / "clean.txt").write_text("nothing\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output
+
+    def test_scan_skips_binary_files(self, tmp_path):
+        (tmp_path / "binary.dat").write_bytes(b"\x00\x01\x02\xff\xfe")
+        (tmp_path / "clean.txt").write_text("nothing\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", str(tmp_path)])
+        assert result.exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,3 +182,28 @@ class TestProviderConfig:
     def test_custom_auth_header(self):
         p = ProviderConfig(name="test", base_url="https://test.com", auth_header="X-Key")
         assert p.auth_header == "X-Key"
+
+
+class TestConfigEnvOverridesExtended:
+    def test_log_format_override(self, monkeypatch):
+        monkeypatch.setenv("SECRETGATE_LOG_FORMAT", "json")
+        cfg = Config.load(None)
+        assert cfg.log_format == "json"
+
+    def test_audit_log_override(self, monkeypatch):
+        monkeypatch.setenv("SECRETGATE_AUDIT_LOG", "/tmp/audit.log")
+        cfg = Config.load(None)
+        assert cfg.audit_log == Path("/tmp/audit.log")
+
+
+class TestVersionConsistency:
+    def test_init_matches_pyproject(self):
+        """__init__.__version__ should match pyproject.toml version."""
+        import tomllib
+
+        from secretgate import __version__
+
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        assert __version__ == data["project"]["version"]


### PR DESCRIPTION
## Changes

### Bug fixes
- **Version mismatch**: `__init__.__version__` was `0.6.0` while `pyproject.toml` had `0.7.0`. Synced to `0.7.0`.
- **Directory scanning in CLI**: `secretgate scan src/` would crash with `IsADirectoryError`. Now recursively walks directories, skipping hidden dirs (e.g. `.git`) and gracefully handling binary/unreadable files.

### Enhancements
- **Config env overrides**: Added `SECRETGATE_LOG_FORMAT` and `SECRETGATE_AUDIT_LOG` environment variable overrides to `Config.load()`, matching the pattern of existing env var support.

### Tests (7 new, 309 total)
- Directory scanning: secrets in subdirs, clean dirs, hidden dir skipping, binary file handling
- Config: `log_format` and `audit_log` env overrides
- Version consistency: validates `__init__.__version__` matches `pyproject.toml`

All existing 302 tests continue to pass. `ruff check` clean.