### PR TITLE
fix: sync __version__ to 0.7.0 and add SECRETGATE_LOG_FORMAT/AUDIT_LOG env overrides

### DIFF
--- a/src/secretgate/__init__.py
+++ b/src/secretgate/__init__.py
@@ -1,3 +1,3 @@
 """secretgate — lean security proxy for AI coding tools."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/secretgate/config.py
+++ b/src/secretgate/config.py
@@ -136,6 +136,10 @@ class Config:
             cfg.forward_proxy_port = int(fpp)
         if certs := os.environ.get("SECRETGATE_CERTS_DIR"):
             cfg.certs_dir = Path(certs)
+        if log_fmt := os.environ.get("SECRETGATE_LOG_FORMAT"):
+            cfg.log_format = log_fmt
+        if audit := os.environ.get("SECRETGATE_AUDIT_LOG"):
+            cfg.audit_log = Path(audit)
 
         # Set up default providers if none configured
         if not cfg.providers:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,3 +182,28 @@ class TestProviderConfig:
     def test_custom_auth_header(self):
         p = ProviderConfig(name="test", base_url="https://test.com", auth_header="X-Key")
         assert p.auth_header == "X-Key"
+
+
+class TestConfigEnvOverridesExtended:
+    def test_log_format_override(self, monkeypatch):
+        monkeypatch.setenv("SECRETGATE_LOG_FORMAT", "json")
+        cfg = Config.load(None)
+        assert cfg.log_format == "json"
+
+    def test_audit_log_override(self, monkeypatch):
+        monkeypatch.setenv("SECRETGATE_AUDIT_LOG", "/tmp/audit.log")
+        cfg = Config.load(None)
+        assert cfg.audit_log == Path("/tmp/audit.log")
+
+
+class TestVersionConsistency:
+    def test_init_matches_pyproject(self):
+        """__init__.__version__ should match pyproject.toml version."""
+        import tomllib
+
+        from secretgate import __version__
+
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        assert __version__ == data["project"]["version"]


### PR DESCRIPTION
## Summary

- **Version mismatch**: `__init__.__version__` was `0.6.0` while `pyproject.toml` had `0.7.0`. Synced to `0.7.0`.
- **Config env overrides**: Added `SECRETGATE_LOG_FORMAT` and `SECRETGATE_AUDIT_LOG` environment variable overrides to `Config.load()`, matching the pattern of existing env var support.

## Changes

- `src/secretgate/__init__.py` — version bump to 0.7.0
- `src/secretgate/config.py` — two new env var overrides
- `tests/test_config.py` — 3 new tests (log_format override, audit_log override, version consistency)

## Test plan

- [ ] `pytest tests/test_config.py` — all config tests pass
- [ ] `python -c "import secretgate; print(secretgate.__version__)"` returns `0.7.0`
- [ ] `SECRETGATE_LOG_FORMAT=json secretgate serve` starts without error

---
*Closes the version/config portion of the mixed PRs (#52, #53, #54). Clean replacement.*