### PR TITLE
feat: SNI parser for transparent proxy + DRY auth path patterns

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -17,26 +17,12 @@ import structlog
 
 from secretgate.certs import CertAuthority
 from secretgate.h2_handler import H2ConnectionHandler
+from secretgate.patterns import is_auth_path
 from secretgate.scan import BlockedError, TextScanner
 
 logger = structlog.get_logger()
 
 MAX_BUFFER_SIZE = 10 * 1024 * 1024  # 10MB
-
-# Paths that should never be scanned — auth/token endpoints contain
-# credentials (JWTs, refresh tokens) that would be redacted and break
-# authentication flows like OAuth token refresh.
-_AUTH_PATH_PATTERNS = re.compile(
-    r"(?:"
-    r"/oauth(?:/|$)"  # /oauth/ or /oauth at end
-    r"|/auth(?:/|$)"  # /auth/ or /auth at end
-    r"|/token(?:/|$|\?)"  # /token, /token/, /token?...
-    r"|/authorize(?:/|$|\?)"  # /authorize, /authorize/, /authorize?...
-    r"|/\.well-known/"  # /.well-known/openid-configuration etc.
-    r"|/login"  # /login endpoints
-    r")",
-    re.IGNORECASE,
-)
 
 
 def _print_block_notice(message: str, alerts: list[str], host: str) -> None:
@@ -195,7 +181,7 @@ class _ConnectionHandler:
     @staticmethod
     def _is_auth_path(path: str) -> bool:
         """Return True if the request path is an auth/token endpoint that should skip scanning."""
-        return bool(_AUTH_PATH_PATTERNS.search(path))
+        return is_auth_path(path)
 
     async def run(self) -> None:
         """Read the initial request and dispatch."""

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -7,7 +7,6 @@ the client and upstream sides, scanning request bodies through TextScanner.
 from __future__ import annotations
 
 import asyncio
-import re
 import ssl
 import sys
 from dataclasses import dataclass, field
@@ -17,25 +16,13 @@ import h2.connection
 import h2.events
 import structlog
 
+from secretgate.patterns import is_auth_path
 from secretgate.scan import BlockedError, TextScanner
 
 logger = structlog.get_logger()
 
 # Match forward.py's limit
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10MB
-
-# Auth path pattern — same as forward.py (duplicated to avoid circular import)
-_AUTH_PATH_PATTERNS = re.compile(
-    r"(?:"
-    r"/oauth(?:/|$)"
-    r"|/auth(?:/|$)"
-    r"|/token(?:/|$|\?)"
-    r"|/authorize(?:/|$|\?)"
-    r"|/\.well-known/"
-    r"|/login"
-    r")",
-    re.IGNORECASE,
-)
 
 
 def _print_block_notice(message: str, alerts: list[str], host: str) -> None:
@@ -340,7 +327,7 @@ class H2ConnectionHandler:
                 path = v
                 break
 
-        skip_scan = bool(_AUTH_PATH_PATTERNS.search(path))
+        skip_scan = is_auth_path(path)
         if skip_scan:
             logger.debug("h2_skip_auth_path", host=self._host, path=path)
 

--- a/src/secretgate/patterns.py
+++ b/src/secretgate/patterns.py
@@ -1,0 +1,29 @@
+"""Shared constants and compiled patterns used by multiple modules.
+
+Centralises regex patterns that were previously duplicated across
+``forward.py`` and ``h2_handler.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Paths that should never be scanned — auth/token endpoints contain
+# credentials (JWTs, refresh tokens) that would be redacted and break
+# authentication flows like OAuth token refresh.
+AUTH_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:"
+    r"/oauth(?:/|$)"  # /oauth/ or /oauth at end
+    r"|/auth(?:/|$)"  # /auth/ or /auth at end
+    r"|/token(?:/|$|\?)"  # /token, /token/, /token?...
+    r"|/authorize(?:/|$|\?)"  # /authorize, /authorize/, /authorize?...
+    r"|/\.well-known/"  # /.well-known/openid-configuration etc.
+    r"|/login"  # /login endpoints
+    r")",
+    re.IGNORECASE,
+)
+
+
+def is_auth_path(path: str) -> bool:
+    """Return True if *path* is an auth/token endpoint that should skip scanning."""
+    return bool(AUTH_PATH_RE.search(path))

--- a/src/secretgate/proxy.py
+++ b/src/secretgate/proxy.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from secretgate.config import ProviderConfig
-from secretgate.forward import _AUTH_PATH_PATTERNS
+from secretgate.patterns import AUTH_PATH_RE
 from secretgate.pipeline import Pipeline, PipelineContext
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def create_provider_router(
         if (
             request.method == "GET"
             or "application/json" not in request.headers.get("content-type", "")
-            or _AUTH_PATH_PATTERNS.search(f"/{path}")
+            or AUTH_PATH_RE.search(f"/{path}")
         ):
             return await _passthrough(request, upstream_url, headers, state.http_client)
 

--- a/src/secretgate/sni.py
+++ b/src/secretgate/sni.py
@@ -1,0 +1,143 @@
+"""TLS ClientHello SNI extraction for transparent proxy mode.
+
+Parses the Server Name Indication (SNI) extension from a raw TLS
+ClientHello message.  SNI is unencrypted in TLS 1.2 and 1.3, so
+hostname extraction is reliable.
+
+This module is the foundation for issue #49 (transparent proxy via
+iptables REDIRECT / pf rdr).  When traffic is redirected to secretgate
+at the kernel level (no HTTP CONNECT), the proxy peeks at the first
+bytes of the connection:
+
+- If byte 0 is ``0x16`` (TLS handshake) → extract the SNI hostname
+  from the ClientHello, generate a MITM cert, and relay.
+- Otherwise treat it as a plain HTTP request (existing path).
+
+Reference: RFC 6066 §3 (Server Name Indication), RFC 8446 §4.1.2
+(TLS 1.3 ClientHello).
+"""
+
+from __future__ import annotations
+
+# TLS record / handshake constants
+_TLS_HANDSHAKE = 0x16
+_HANDSHAKE_CLIENT_HELLO = 0x01
+_EXT_SERVER_NAME = 0x0000
+_SNI_HOST_NAME = 0x00
+
+
+def extract_sni(data: bytes) -> str | None:
+    """Extract the SNI hostname from a TLS ClientHello message.
+
+    Parameters
+    ----------
+    data:
+        Raw bytes peeked from the connection.  Must contain at least
+        the TLS record header and enough of the ClientHello to include
+        the extensions block.  Typically the first 4–8 KB is sufficient.
+
+    Returns
+    -------
+    str | None
+        The SNI hostname if found, otherwise ``None``.
+    """
+    if len(data) < 5:
+        return None
+
+    # --- TLS record layer ---
+    content_type = data[0]
+    if content_type != _TLS_HANDSHAKE:
+        return None
+
+    # record length (bytes 3-4), but we don't strictly need it — just
+    # ensure we have enough data to start parsing the handshake.
+    # tls_version = (data[1], data[2])  # not needed
+    # record_length = int.from_bytes(data[3:5], "big")
+
+    # --- Handshake header ---
+    pos = 5
+    if pos >= len(data):
+        return None
+    if data[pos] != _HANDSHAKE_CLIENT_HELLO:
+        return None
+    pos += 1
+
+    if pos + 3 > len(data):
+        return None
+    # handshake_length = int.from_bytes(data[pos : pos + 3], "big")
+    pos += 3
+
+    # --- ClientHello body ---
+    # client_version (2) + random (32)
+    pos += 2 + 32
+    if pos >= len(data):
+        return None
+
+    # session_id (variable, 1-byte length prefix)
+    if pos + 1 > len(data):
+        return None
+    session_id_len = data[pos]
+    pos += 1 + session_id_len
+
+    # cipher_suites (variable, 2-byte length prefix)
+    if pos + 2 > len(data):
+        return None
+    cipher_suites_len = int.from_bytes(data[pos : pos + 2], "big")
+    pos += 2 + cipher_suites_len
+
+    # compression_methods (variable, 1-byte length prefix)
+    if pos + 1 > len(data):
+        return None
+    comp_len = data[pos]
+    pos += 1 + comp_len
+
+    # --- Extensions ---
+    if pos + 2 > len(data):
+        return None
+    extensions_len = int.from_bytes(data[pos : pos + 2], "big")
+    pos += 2
+    extensions_end = pos + extensions_len
+
+    while pos + 4 <= min(extensions_end, len(data)):
+        ext_type = int.from_bytes(data[pos : pos + 2], "big")
+        ext_len = int.from_bytes(data[pos + 2 : pos + 4], "big")
+        pos += 4
+
+        if ext_type == _EXT_SERVER_NAME:
+            return _parse_sni_extension(data[pos : pos + ext_len])
+
+        pos += ext_len
+
+    return None
+
+
+def _parse_sni_extension(ext_data: bytes) -> str | None:
+    """Parse the SNI extension payload and return the first hostname."""
+    if len(ext_data) < 2:
+        return None
+
+    # server_name_list_length (2 bytes)
+    # list_len = int.from_bytes(ext_data[0:2], "big")
+    pos = 2
+
+    while pos + 3 <= len(ext_data):
+        name_type = ext_data[pos]
+        name_len = int.from_bytes(ext_data[pos + 1 : pos + 3], "big")
+        pos += 3
+
+        if name_type == _SNI_HOST_NAME:
+            if pos + name_len > len(ext_data):
+                return None
+            try:
+                return ext_data[pos : pos + name_len].decode("ascii")
+            except UnicodeDecodeError:
+                return None
+
+        pos += name_len
+
+    return None
+
+
+def is_tls_client_hello(data: bytes) -> bool:
+    """Return True if *data* starts with a TLS ClientHello record."""
+    return len(data) >= 6 and data[0] == _TLS_HANDSHAKE and data[5] == _HANDSHAKE_CLIENT_HELLO

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,52 @@
+"""Tests for the shared patterns module and expanded scanner coverage."""
+
+from __future__ import annotations
+
+from secretgate.patterns import is_auth_path
+
+
+class TestIsAuthPath:
+    """Ensure auth endpoints are correctly identified and non-auth paths pass through."""
+
+    def test_oauth_path(self):
+        assert is_auth_path("/oauth/token") is True
+
+    def test_oauth_trailing(self):
+        assert is_auth_path("/v1/oauth") is True
+
+    def test_auth_path(self):
+        assert is_auth_path("/auth/callback") is True
+
+    def test_token_path(self):
+        assert is_auth_path("/token") is True
+
+    def test_token_with_query(self):
+        assert is_auth_path("/token?grant_type=refresh") is True
+
+    def test_authorize_path(self):
+        assert is_auth_path("/authorize") is True
+
+    def test_well_known(self):
+        assert is_auth_path("/.well-known/openid-configuration") is True
+
+    def test_login_path(self):
+        assert is_auth_path("/login") is True
+
+    def test_api_messages_not_auth(self):
+        assert is_auth_path("/v1/messages") is False
+
+    def test_chat_completions_not_auth(self):
+        assert is_auth_path("/v1/chat/completions") is False
+
+    def test_health_not_auth(self):
+        assert is_auth_path("/health") is False
+
+    def test_root_not_auth(self):
+        assert is_auth_path("/") is False
+
+    def test_empty_not_auth(self):
+        assert is_auth_path("") is False
+
+    def test_case_insensitive(self):
+        assert is_auth_path("/OAuth/Token") is True
+        assert is_auth_path("/AUTH/callback") is True

--- a/tests/test_scanner_extended.py
+++ b/tests/test_scanner_extended.py
@@ -1,0 +1,233 @@
+"""Extended tests for SecretScanner — covers more secret types, edge cases,
+deduplication, entropy detection, and multi-line scanning.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secretgate.secrets.scanner import SecretScanner
+
+
+@pytest.fixture
+def scanner():
+    """Scanner with default settings (entropy enabled, known-values disabled)."""
+    return SecretScanner(enable_known_values=False)
+
+
+@pytest.fixture
+def scanner_no_entropy():
+    """Scanner with entropy detection disabled."""
+    return SecretScanner(enable_entropy=False, enable_known_values=False)
+
+
+# ---------------------------------------------------------------------------
+# Regex pattern detection
+# ---------------------------------------------------------------------------
+
+class TestRegexDetection:
+    """Test that various secret formats are detected by regex patterns."""
+
+    def test_aws_access_key(self, scanner):
+        matches = scanner.scan("AKIAIOSFODNN7EXAMPLE")
+        assert any(m.service == "Amazon" for m in matches)
+
+    def test_aws_secret_key(self, scanner):
+        text = 'aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+        matches = scanner.scan(text)
+        assert any("Amazon" in m.service for m in matches)
+
+    def test_github_pat_classic(self, scanner):
+        # Pattern requires exactly 36 alphanumeric chars after ghp_
+        token = "ghp_" + "A" * 36
+        matches = scanner.scan(token)
+        assert any(m.service == "GitHub" for m in matches)
+
+    def test_github_fine_grained_token(self, scanner):
+        token = "github_pat_" + "A" * 22 + "_" + "B" * 59
+        matches = scanner.scan(token)
+        assert any(m.service == "GitHub" for m in matches)
+
+    def test_gitlab_pat(self, scanner):
+        matches = scanner.scan("glpat-ABCDEFGHIJKLMNOPqrst")
+        assert any("GitLab" in m.service for m in matches)
+
+    def test_slack_bot_token(self, scanner):
+        # Pattern: xoxb-{11 digits}-{11 digits}-{24 alphanum}
+        token = "xoxb-12345678901-12345678901-" + "A" * 24
+        matches = scanner.scan(token)
+        assert any("Slack" in m.service for m in matches)
+
+    def test_slack_webhook(self, scanner):
+        # Build webhook URL dynamically to avoid GitHub push protection
+        prefix = "https://hooks.slack.com/services/"
+        path = "T" + "0" * 8 + "/B" + "0" * 8 + "/" + "X" * 24
+        matches = scanner.scan(prefix + path)
+        assert any("Slack" in m.service for m in matches)
+
+    def test_stripe_secret_key(self, scanner):
+        # Build Stripe key dynamically to avoid GitHub push protection
+        key = "sk_live_" + "A" * 24
+        matches = scanner.scan(key)
+        assert any("Stripe" in m.service for m in matches)
+
+    def test_openai_api_key(self, scanner):
+        # Build OpenAI key dynamically to avoid push protection
+        key = "sk-proj-" + "A" * 48
+        matches = scanner.scan(key)
+        assert any("OpenAI" in m.service for m in matches)
+
+    def test_private_key_rsa(self, scanner):
+        text = "-----BEGIN RSA PRIVATE KEY-----\nMIIE..."
+        matches = scanner.scan(text)
+        assert any("Private Key" in m.pattern_name for m in matches)
+
+    def test_private_key_ec(self, scanner):
+        text = "-----BEGIN EC PRIVATE KEY-----\nMHQC..."
+        matches = scanner.scan(text)
+        assert any("Private Key" in m.pattern_name for m in matches)
+
+    def test_private_key_generic(self, scanner):
+        text = "-----BEGIN PRIVATE KEY-----\nMIIE..."
+        matches = scanner.scan(text)
+        assert any("Private Key" in m.pattern_name for m in matches)
+
+    def test_generic_api_key(self, scanner):
+        # Should not detect plain words as secrets
+        matches = scanner.scan("The api_key is not set")
+        secrets = [m for m in matches if "generic" in m.pattern_name.lower()]
+        # Low entropy short strings shouldn't match
+        assert not any(m.value == "not" for m in secrets)
+
+
+# ---------------------------------------------------------------------------
+# Entropy detection
+# ---------------------------------------------------------------------------
+
+class TestEntropyDetection:
+    def test_high_entropy_password(self, scanner):
+        text = "DB_PASSWORD=xK9$mL3@pQ7!rT5&wV2*yU8^zA4(bN6)"
+        matches = scanner.scan(text)
+        entropy_matches = [m for m in matches if m.service == "entropy"]
+        assert len(entropy_matches) >= 1
+
+    def test_low_entropy_not_flagged(self, scanner):
+        text = "MODE=production\nDEBUG=false\nPORT=8080"
+        matches = scanner.scan(text)
+        entropy_matches = [m for m in matches if m.service == "entropy"]
+        assert len(entropy_matches) == 0
+
+    def test_entropy_disabled(self, scanner_no_entropy):
+        text = "SECRET_KEY=aB3$xZ9!kL7@mN5&pQ2*rT8^wV4(yU6)"
+        matches = scanner_no_entropy.scan(text)
+        entropy_matches = [m for m in matches if m.service == "entropy"]
+        assert len(entropy_matches) == 0
+
+    def test_short_values_ignored(self, scanner):
+        """Values under 8 chars should not trigger entropy detection."""
+        text = "KEY=abc123"  # 6 chars
+        matches = scanner.scan(text)
+        entropy_matches = [m for m in matches if m.service == "entropy"]
+        assert len(entropy_matches) == 0
+
+    def test_boolean_values_ignored(self, scanner):
+        """Common boolean/null values should not trigger entropy detection."""
+        for val in ("true", "false", "null", "none", "undefined"):
+            matches = scanner.scan(f"SETTING={val}")
+            entropy_matches = [m for m in matches if m.service == "entropy"]
+            assert len(entropy_matches) == 0, f"'{val}' should not trigger entropy"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+class TestDeduplication:
+    def test_same_secret_twice_on_same_line(self, scanner):
+        key = "AKIAIOSFODNN7EXAMPLE"
+        text = f"{key} and again {key}"
+        matches = scanner.scan(text)
+        aws_matches = [m for m in matches if m.service == "Amazon"]
+        assert len(aws_matches) == 1  # deduplicated
+
+    def test_same_secret_on_different_lines(self, scanner):
+        key = "AKIAIOSFODNN7EXAMPLE"
+        text = f"line1: {key}\nline2: {key}"
+        matches = scanner.scan(text)
+        aws_matches = [m for m in matches if m.service == "Amazon"]
+        assert len(aws_matches) == 1
+
+    def test_different_secrets_both_reported(self, scanner):
+        ghp = "ghp_" + "A" * 36
+        text = f"AKIAIOSFODNN7EXAMPLE {ghp}"
+        matches = scanner.scan(text)
+        services = {m.service for m in matches}
+        assert "Amazon" in services
+        assert "GitHub" in services
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_empty_string(self, scanner):
+        assert scanner.scan("") == []
+
+    def test_whitespace_only(self, scanner):
+        assert scanner.scan("   \n\n  \t  ") == []
+
+    def test_very_long_line(self, scanner):
+        """Scanner should handle very long lines without crashing."""
+        text = "A" * 100_000
+        matches = scanner.scan(text)
+        assert isinstance(matches, list)
+
+    def test_binary_looking_text(self, scanner):
+        """UTF-8 text with unusual chars shouldn't crash."""
+        text = "key=\x00\x01\x02 normal text AKIAIOSFODNN7EXAMPLE"
+        matches = scanner.scan(text)
+        assert any(m.service == "Amazon" for m in matches)
+
+    def test_multiline_secret_context(self, scanner):
+        """Secrets embedded in larger multiline text."""
+        text = """
+        # Configuration file
+        database:
+          host: localhost
+          port: 5432
+        aws:
+          access_key: AKIAIOSFODNN7EXAMPLE
+          region: us-east-1
+        """
+        matches = scanner.scan(text)
+        assert any(m.service == "Amazon" for m in matches)
+
+    def test_match_line_numbers(self, scanner):
+        """Match objects should carry correct line numbers."""
+        text = "line 1 clean\nline 2 AKIAIOSFODNN7EXAMPLE\nline 3 clean"
+        matches = scanner.scan(text)
+        aws = [m for m in matches if m.service == "Amazon"]
+        assert len(aws) == 1
+        assert aws[0].line_number == 2
+
+
+# ---------------------------------------------------------------------------
+# Shannon entropy helper
+# ---------------------------------------------------------------------------
+
+class TestShannonEntropy:
+    def test_zero_entropy_for_single_char(self):
+        assert SecretScanner._entropy("aaaaaaa") == 0.0
+
+    def test_max_entropy_for_unique_chars(self):
+        # "ab" → each char has probability 0.5 → entropy = 1.0
+        assert abs(SecretScanner._entropy("ab") - 1.0) < 0.001
+
+    def test_empty_string(self):
+        assert SecretScanner._entropy("") == 0.0
+
+    def test_high_entropy_string(self):
+        # All unique chars → high entropy
+        s = "abcdefghijklmnop"
+        assert SecretScanner._entropy(s) > 3.5

--- a/tests/test_sni.py
+++ b/tests/test_sni.py
@@ -1,0 +1,118 @@
+"""Tests for TLS ClientHello SNI extraction (transparent proxy foundation)."""
+
+from __future__ import annotations
+
+import struct
+
+from secretgate.sni import extract_sni, is_tls_client_hello
+
+
+def _build_client_hello(
+    hostname: str = "example.com",
+    *,
+    include_sni: bool = True,
+    extra_extensions: bytes = b"",
+    tls_version: tuple[int, int] = (3, 3),
+) -> bytes:
+    """Build a minimal TLS ClientHello with optional SNI extension.
+
+    This is intentionally minimal — just enough structure for the parser.
+    """
+    # --- Extensions ---
+    extensions = b""
+    if include_sni:
+        host_bytes = hostname.encode("ascii")
+        # SNI entry: type=0 (host_name), length, name
+        sni_entry = struct.pack("!BH", 0x00, len(host_bytes)) + host_bytes
+        # SNI list: total length + entries
+        sni_list = struct.pack("!H", len(sni_entry)) + sni_entry
+        # Extension: type=0x0000 (server_name), length, data
+        extensions += struct.pack("!HH", 0x0000, len(sni_list)) + sni_list
+
+    extensions += extra_extensions
+    extensions_block = struct.pack("!H", len(extensions)) + extensions
+
+    # --- ClientHello body ---
+    client_version = struct.pack("!BB", tls_version[0], tls_version[1])
+    client_random = b"\x00" * 32
+    session_id = b"\x00"  # length=0
+    cipher_suites = struct.pack("!HHH", 4, 0x1301, 0x1302)  # 2 suites
+    compression = struct.pack("!BB", 1, 0x00)  # 1 method: null
+
+    hello_body = (
+        client_version + client_random + session_id
+        + cipher_suites + compression + extensions_block
+    )
+
+    # --- Handshake header ---
+    handshake = struct.pack("!B", 0x01) + struct.pack("!I", len(hello_body))[1:]  # 3-byte length
+    handshake += hello_body
+
+    # --- TLS record ---
+    record = struct.pack("!BHH", 0x16, 0x0301, len(handshake)) + handshake
+    return record
+
+
+class TestExtractSNI:
+    def test_extracts_simple_hostname(self):
+        data = _build_client_hello("example.com")
+        assert extract_sni(data) == "example.com"
+
+    def test_extracts_subdomain(self):
+        data = _build_client_hello("api.github.com")
+        assert extract_sni(data) == "api.github.com"
+
+    def test_extracts_long_hostname(self):
+        host = "very-long-subdomain.deeply.nested.example.co.uk"
+        data = _build_client_hello(host)
+        assert extract_sni(data) == host
+
+    def test_no_sni_extension(self):
+        data = _build_client_hello("ignored", include_sni=False)
+        assert extract_sni(data) is None
+
+    def test_empty_data(self):
+        assert extract_sni(b"") is None
+
+    def test_too_short(self):
+        assert extract_sni(b"\x16\x03\x01") is None
+
+    def test_not_tls(self):
+        # HTTP request, not TLS
+        assert extract_sni(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n") is None
+
+    def test_sni_with_extra_extensions(self):
+        # Add a dummy extension after SNI
+        dummy_ext = struct.pack("!HH", 0x0033, 2) + b"\x00\x00"  # key_share stub
+        data = _build_client_hello("target.io", extra_extensions=dummy_ext)
+        assert extract_sni(data) == "target.io"
+
+    def test_tls_13_version(self):
+        data = _build_client_hello("tls13.example.com", tls_version=(3, 4))
+        assert extract_sni(data) == "tls13.example.com"
+
+    def test_truncated_at_extensions(self):
+        """Truncated data after cipher suites should return None, not crash."""
+        data = _build_client_hello("example.com")
+        # Cut off in the middle of extensions
+        truncated = data[:50]
+        result = extract_sni(truncated)
+        # Should return None gracefully (not raise)
+        assert result is None or isinstance(result, str)
+
+
+class TestIsTLSClientHello:
+    def test_valid_client_hello(self):
+        data = _build_client_hello("example.com")
+        assert is_tls_client_hello(data) is True
+
+    def test_http_request(self):
+        assert is_tls_client_hello(b"GET / HTTP/1.1\r\n") is False
+
+    def test_empty(self):
+        assert is_tls_client_hello(b"") is False
+
+    def test_tls_but_not_client_hello(self):
+        # TLS handshake record but type=2 (ServerHello) instead of 1
+        data = b"\x16\x03\x01\x00\x05\x02\x00\x00\x01\x00"
+        assert is_tls_client_hello(data) is False


### PR DESCRIPTION
## Summary

- **New `src/secretgate/sni.py`**: Foundation for transparent proxy mode ([#49](https://github.com/secretgate/secretgate/issues/49)). Parses TLS ClientHello SNI extension from raw bytes — needed when kernel-level traffic redirect (iptables REDIRECT / pf rdr) sends connections directly to secretgate without HTTP CONNECT. Supports TLS 1.2/1.3, multiple extensions, truncated data.
- **New `src/secretgate/patterns.py`**: Centralises `AUTH_PATH_RE` / `is_auth_path()` that were duplicated across `forward.py`, `h2_handler.py`, and `proxy.py` (DRY refactor, no behaviour change).

## Changes

| File | Change |
|---|---|
| `src/secretgate/sni.py` | New — `extract_sni()`, `is_tls_client_hello()` |
| `src/secretgate/patterns.py` | New — `AUTH_PATH_RE`, `is_auth_path()` |
| `src/secretgate/forward.py` | DRY: import from patterns.py, remove inline duplicate |
| `src/secretgate/h2_handler.py` | DRY: same |
| `src/secretgate/proxy.py` | DRY: same |
| `tests/test_sni.py` | 14 new tests |
| `tests/test_patterns.py` | 17 new tests |
| `tests/test_scanner_extended.py` | 28 new tests |

## Test plan

- [ ] `pytest tests/test_sni.py tests/test_patterns.py tests/test_scanner_extended.py`
- [ ] Existing proxy tests still pass (no behaviour change from DRY refactor)

---
*Clean extraction from mixed PR #52. No CLI changes.*