### PR TITLE
feat: WebSocket upgrade passthrough in forward proxy

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -408,6 +408,22 @@ class _ConnectionHandler:
                 await self._send_error(client_writer, 400, "Bad Request", "Malformed HTTP request")
                 return
 
+            # Detect WebSocket upgrade — forward headers then switch to raw pipe
+            if (
+                req_headers.get("upgrade", "").lower() == "websocket"
+                and "upgrade" in req_headers.get("connection", "").lower()
+            ):
+                logger.info("websocket_upgrade_detected", host=host)
+                upstream_writer.write(req_header_data)
+                await upstream_writer.drain()
+                # Relay the 101 response + all subsequent frames as raw bytes
+                await asyncio.gather(
+                    self._pipe(upstream_reader, client_writer),
+                    self._pipe(client_reader, upstream_writer),
+                    return_exceptions=True,
+                )
+                return
+
             # Read the request body
             content_length_str = req_headers.get("content-length")
             req_transfer = req_headers.get("transfer-encoding", "").lower()


### PR DESCRIPTION
## Summary

Addresses [#9](https://github.com/secretgate/secretgate/issues/9) (option 1).

Detects `Connection: Upgrade` + `Upgrade: websocket` in the HTTP relay and switches to a raw bidirectional pipe. Previously the forward proxy would behave unpredictably on WebSocket connections.

**Behaviour**: The HTTP upgrade handshake headers are forwarded to upstream; the 101 response and all subsequent WebSocket frames pass through as raw bytes (not scanned — binary protocol). Clean shutdown on either side closes both connections.

## Changes

- `src/secretgate/forward.py` — 16 lines in `_relay_http`: detect upgrade, forward, switch to raw pipe

## Test plan

- [ ] Connect a WebSocket client through the proxy — upgrade succeeds
- [ ] Non-WebSocket HTTP requests are unaffected
- [ ] Proxy shuts down cleanly when WebSocket client disconnects

---
*Clean extraction from mixed PR #53. Single-file, single-purpose change.*