### PR TITLE
feat: per-request scan mode override via X-Secretgate-* headers

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -469,17 +469,37 @@ class _ConnectionHandler:
             else:
                 content_length = len(body)
 
+            # Per-request scan overrides via X-Secretgate-* headers.
+            # Strip them before forwarding so they never reach the upstream.
+            scan_mode_override = req_headers.pop("x-secretgate-mode", None)
+            if scan_mode_override and scan_mode_override not in ("redact", "audit", "block"):
+                scan_mode_override = None
+            skip_scan_header = req_headers.pop("x-secretgate-skip", "").lower() in ("1", "true")
+            if scan_mode_override or skip_scan_header:
+                headers_text = headers_bytes.decode("latin-1")
+                headers_text = re.sub(r"(?i)x-secretgate-mode:\s*[^\r\n]*\r\n", "", headers_text)
+                headers_text = re.sub(r"(?i)x-secretgate-skip:\s*[^\r\n]*\r\n", "", headers_text)
+                headers_bytes = headers_text.encode("latin-1")
+                if scan_mode_override:
+                    logger.debug(
+                        "forward_scan_mode_override", host=host, mode=scan_mode_override
+                    )
+                if skip_scan_header:
+                    logger.debug("forward_scan_skip_header", host=host)
+
             # Scan outbound request body (skip auth endpoints to avoid
             # redacting OAuth tokens / refresh tokens)
             req_path = request_line.split(" ", 2)[1] if request_line else ""
             content_type = req_headers.get("content-type", "application/octet-stream")
             scanned_body = body
-            skip_scan = self._is_auth_path(req_path)
-            if skip_scan:
+            skip_scan = self._is_auth_path(req_path) or skip_scan_header
+            if self._is_auth_path(req_path):
                 logger.debug("forward_skip_auth_path", host=host, path=req_path)
             if body and content_length > 0 and not skip_scan:
                 try:
-                    scanned_body, alerts = self._scanner.scan_body(body, content_type)
+                    scanned_body, alerts = self._scanner.scan_body(
+                        body, content_type, mode_override=scan_mode_override
+                    )
                     for alert in alerts:
                         logger.warning("forward_proxy_alert", host=host, alert=alert)
                 except BlockedError as exc:

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -60,6 +60,7 @@ class _StreamState:
     request_complete: bool = False
     upstream_stream_id: int | None = None
     skip_scan: bool = False
+    scan_mode_override: str | None = None
 
 
 class H2ConnectionHandler:
@@ -335,18 +336,35 @@ class H2ConnectionHandler:
             decoded.append((n, v))
 
         path = ""
+        scan_mode_override = None
+        skip_scan_header = False
+        filtered = []
         for n, v in decoded:
             if n == ":path":
                 path = v
-                break
+            if n == "x-secretgate-mode":
+                if v in ("redact", "audit", "block"):
+                    scan_mode_override = v
+                continue  # strip from forwarded headers
+            if n == "x-secretgate-skip":
+                if v.lower() in ("1", "true"):
+                    skip_scan_header = True
+                continue  # strip from forwarded headers
+            filtered.append((n, v))
 
-        skip_scan = bool(_AUTH_PATH_PATTERNS.search(path))
-        if skip_scan:
+        if scan_mode_override:
+            logger.debug("h2_scan_mode_override", host=self._host, mode=scan_mode_override)
+        if skip_scan_header:
+            logger.debug("h2_scan_skip_header", host=self._host)
+
+        skip_scan = bool(_AUTH_PATH_PATTERNS.search(path)) or skip_scan_header
+        if _AUTH_PATH_PATTERNS.search(path):
             logger.debug("h2_skip_auth_path", host=self._host, path=path)
 
         self._streams[stream_id] = _StreamState(
-            request_headers=decoded,
+            request_headers=filtered,
             skip_scan=skip_scan,
+            scan_mode_override=scan_mode_override,
         )
 
     async def _on_request_data(
@@ -386,7 +404,9 @@ class H2ConnectionHandler:
         scanned_body = body
         if body and not state.skip_scan:
             try:
-                scanned_body, alerts = self._scanner.scan_body(body, content_type)
+                scanned_body, alerts = self._scanner.scan_body(
+                    body, content_type, mode_override=state.scan_mode_override
+                )
                 for alert in alerts:
                     logger.warning("h2_forward_proxy_alert", host=self._host, alert=alert)
             except BlockedError as exc:

--- a/src/secretgate/scan.py
+++ b/src/secretgate/scan.py
@@ -66,7 +66,9 @@ class TextScanner:
         # Also detect by PACK magic in the body (could be generic octet-stream)
         return PACK_MAGIC in body[:8192]  # only check first 8KB for the magic
 
-    def scan_packfile(self, body: bytes) -> tuple[bytes, list[str]]:
+    def scan_packfile(
+        self, body: bytes, *, mode_override: str | None = None
+    ) -> tuple[bytes, list[str]]:
         """Scan a git packfile for secrets.
 
         Extracts text from commit, blob, and tag objects and scans each.
@@ -74,6 +76,7 @@ class TextScanner:
         In block/redact mode: raises BlockedError (packfiles cannot be safely
         rewritten without corrupting checksums and delta chains).
         """
+        mode = mode_override or self._mode
         alerts: list[str] = []
         texts = extract_texts_from_packfile(body)
 
@@ -98,7 +101,7 @@ class TextScanner:
                 line=m.line_number,
             )
 
-        if self._mode == "audit":
+        if mode == "audit":
             return body, alerts
 
         # Block and redact modes both block — we cannot safely rewrite
@@ -110,13 +113,23 @@ class TextScanner:
             alerts,
         )
 
-    def scan_body(self, body: bytes, content_type: str = "text/plain") -> tuple[bytes, list[str]]:
+    def scan_body(
+        self,
+        body: bytes,
+        content_type: str = "text/plain",
+        *,
+        mode_override: str | None = None,
+    ) -> tuple[bytes, list[str]]:
         """Scan body bytes for secrets. Returns (possibly modified body, alerts).
 
         In block mode, raises BlockedError if secrets are found.
         In audit mode, returns body unchanged but with alerts.
         In redact mode, replaces secrets with [REDACTED] markers.
+
+        ``mode_override`` overrides the scanner's global mode for this call only.
+        Valid values: ``"redact"``, ``"audit"``, ``"block"``.
         """
+        mode = mode_override or self._mode
         alerts: list[str] = []
 
         if not body or not self.should_scan(content_type):
@@ -124,7 +137,7 @@ class TextScanner:
 
         # Route git packfiles to the packfile scanner
         if self._is_git_packfile(body, content_type):
-            return self.scan_packfile(body)
+            return self.scan_packfile(body, mode_override=mode_override)
 
         try:
             text = body.decode("utf-8", errors="replace")
@@ -151,10 +164,10 @@ class TextScanner:
                 line=m.line_number,
             )
 
-        if self._mode == "block":
+        if mode == "block":
             raise BlockedError(f"Request blocked: {len(matches)} secret(s) detected", alerts)
 
-        if self._mode == "audit":
+        if mode == "audit":
             return body, alerts
 
         # Redact mode: replace secrets with deterministic placeholders

--- a/tests/test_scan_mode_override.py
+++ b/tests/test_scan_mode_override.py
@@ -1,0 +1,140 @@
+"""Tests for per-request scan mode override (X-Secretgate-Mode / X-Secretgate-Skip).
+
+Covers:
+- scan_body mode_override parameter
+- forward proxy header stripping + mode override
+- HTTP/2 handler header stripping + mode override
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secretgate.scan import BlockedError, TextScanner
+from secretgate.secrets.scanner import SecretScanner
+
+AWS_KEY = b"AWS_KEY=AKIAIOSFODNN7EXAMPLE\n"
+CLEAN = b'{"model": "claude-3-5-sonnet-20241022", "messages": []}'
+
+
+@pytest.fixture
+def scanner():
+    return SecretScanner()
+
+
+# ---------------------------------------------------------------------------
+# TextScanner.scan_body — mode_override parameter
+# ---------------------------------------------------------------------------
+
+
+class TestScanBodyModeOverride:
+    def test_redact_scanner_can_audit_per_request(self, scanner):
+        """A redact-mode scanner returns body unchanged when override=audit."""
+        ts = TextScanner(scanner, mode="redact")
+        body, alerts = ts.scan_body(AWS_KEY, "text/plain", mode_override="audit")
+        assert body == AWS_KEY  # unchanged
+        assert alerts  # alert still raised
+
+    def test_redact_scanner_can_block_per_request(self, scanner):
+        """A redact-mode scanner raises BlockedError when override=block."""
+        ts = TextScanner(scanner, mode="redact")
+        with pytest.raises(BlockedError):
+            ts.scan_body(AWS_KEY, "text/plain", mode_override="block")
+
+    def test_audit_scanner_can_redact_per_request(self, scanner):
+        """An audit-mode scanner redacts when override=redact."""
+        ts = TextScanner(scanner, mode="audit")
+        body, alerts = ts.scan_body(AWS_KEY, "text/plain", mode_override="redact")
+        assert b"AKIAIOSFODNN7EXAMPLE" not in body
+        assert alerts
+
+    def test_audit_scanner_can_block_per_request(self, scanner):
+        """An audit-mode scanner blocks when override=block."""
+        ts = TextScanner(scanner, mode="audit")
+        with pytest.raises(BlockedError):
+            ts.scan_body(AWS_KEY, "text/plain", mode_override="block")
+
+    def test_block_scanner_can_audit_per_request(self, scanner):
+        """A block-mode scanner passes through when override=audit."""
+        ts = TextScanner(scanner, mode="block")
+        body, alerts = ts.scan_body(AWS_KEY, "text/plain", mode_override="audit")
+        assert body == AWS_KEY
+        assert alerts
+
+    def test_none_override_uses_global_mode(self, scanner):
+        """None override falls back to the scanner's global mode."""
+        ts = TextScanner(scanner, mode="block")
+        with pytest.raises(BlockedError):
+            ts.scan_body(AWS_KEY, "text/plain", mode_override=None)
+
+    def test_clean_body_unaffected_by_override(self, scanner):
+        """No-secret body always passes regardless of override."""
+        ts = TextScanner(scanner, mode="block")
+        body, alerts = ts.scan_body(CLEAN, "application/json", mode_override="block")
+        assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Forward proxy — X-Secretgate-Mode and X-Secretgate-Skip header handling
+# ---------------------------------------------------------------------------
+
+
+class TestForwardProxyHeaderStripping:
+    """Verify X-Secretgate-* headers are stripped before forwarding upstream."""
+
+    def _make_request(self, extra_headers: str = "") -> bytes:
+        return (
+            f"POST /v1/messages HTTP/1.1\r\n"
+            f"Host: api.anthropic.com\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(CLEAN)}\r\n"
+            f"{extra_headers}"
+            f"\r\n"
+        ).encode() + CLEAN
+
+    def test_mode_override_header_stripped(self):
+        """X-Secretgate-Mode must not appear in the forwarded request."""
+        raw = self._make_request("X-Secretgate-Mode: audit\r\n")
+        assert b"X-Secretgate-Mode" in raw  # sanity: present before stripping
+        import re
+        stripped = re.sub(rb"(?i)x-secretgate-mode:\s*[^\r\n]*\r\n", b"", raw)
+        assert b"X-Secretgate-Mode" not in stripped
+        assert b"X-Secretgate-Mode" not in stripped.lower()
+
+    def test_skip_header_stripped(self):
+        """X-Secretgate-Skip must not appear in the forwarded request."""
+        raw = self._make_request("X-Secretgate-Skip: true\r\n")
+        import re
+        stripped = re.sub(rb"(?i)x-secretgate-skip:\s*[^\r\n]*\r\n", b"", raw)
+        assert b"x-secretgate-skip" not in stripped.lower()
+
+    def test_invalid_mode_ignored(self, scanner):
+        """Unknown mode values are ignored (global mode used)."""
+        ts = TextScanner(scanner, mode="redact")
+        # simulate what forward.py does: invalid value → override is None
+        mode = "invalid-mode"
+        effective = mode if mode in ("redact", "audit", "block") else None
+        body, alerts = ts.scan_body(AWS_KEY, "text/plain", mode_override=effective)
+        # Falls back to redact — secret is replaced
+        assert b"AKIAIOSFODNN7EXAMPLE" not in body
+
+
+# ---------------------------------------------------------------------------
+# HTTP/2 handler — _StreamState scan_mode_override field
+# ---------------------------------------------------------------------------
+
+
+class TestH2StreamStateModeOverride:
+    def test_stream_state_defaults(self):
+        """scan_mode_override defaults to None."""
+        from secretgate.h2_handler import _StreamState
+
+        state = _StreamState()
+        assert state.scan_mode_override is None
+        assert state.skip_scan is False
+
+    def test_stream_state_with_override(self):
+        from secretgate.h2_handler import _StreamState
+
+        state = _StreamState(scan_mode_override="audit", skip_scan=False)
+        assert state.scan_mode_override == "audit"


### PR DESCRIPTION
## Summary

Closes #22.

Clients can override scanning behaviour per-request using two request headers that are **stripped before forwarding** (never reach the upstream LLM provider):

| Header | Values | Behaviour |
|---|---|---|
| `X-Secretgate-Mode` | `audit` / `redact` / `block` | Override global mode for this request |
| `X-Secretgate-Skip` | `true` / `1` | Skip scanning entirely for this request |

### Examples

```bash
# Temporarily switch to audit mode to debug a false positive
curl -x http://localhost:8080 https://api.anthropic.com/v1/messages \
  -H "X-Secretgate-Mode: audit" \
  -d '...'

# CI pipeline enforces block mode regardless of server config
curl -x http://localhost:8080 https://api.anthropic.com/v1/messages \
  -H "X-Secretgate-Mode: block" \
  -d '...'
```

## Changes

| File | Change |
|---|---|
| `src/secretgate/scan.py` | `scan_body()` + `scan_packfile()` accept `mode_override` kwarg |
| `src/secretgate/forward.py` | Read + strip headers in `_relay_http`, pass `mode_override` |
| `src/secretgate/h2_handler.py` | Read + strip in `_on_request_headers`, store in `_StreamState`, pass through |
| `tests/test_scan_mode_override.py` | 12 new tests |

## Known limitation

`X-Secretgate-Skip` currently requires no authentication. Auth gating will be added when virtual API keys land ([#21](https://github.com/secretgate/secretgate/issues/21)).

## Test plan

- [ ] `pytest tests/test_scan_mode_override.py` — 12 tests pass
- [ ] Send request with `X-Secretgate-Mode: audit` to a redact-mode proxy — secret passes through unredacted
- [ ] Verify `X-Secretgate-Mode` header is absent from the upstream request
- [ ] Send request with `X-Secretgate-Skip: true` — body not scanned