### PR TITLE
fix: H2 flow control drops data, causing ERR_HTTP2_PROTOCOL_ERROR

### DIFF
--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -232,16 +232,29 @@ class H2ConnectionHandler:
                     await upstream_task
                 except (asyncio.CancelledError, Exception):
                     pass
-                # Re-raise client task exceptions
                 exc = client_task.exception()
+                logger.warning(
+                    "h2_relay_client_done",
+                    host=self._host,
+                    error=type(exc).__name__ if exc else None,
+                    streams=len(self._streams),
+                )
                 if exc and not isinstance(
                     exc, (ConnectionResetError, BrokenPipeError, asyncio.CancelledError)
                 ):
                     raise exc
                 return
 
-            # Upstream closed — cancel client reader, error in-flight streams, reconnect
-            upstream_task.cancel()  # already done, but be safe
+            # Upstream task completed — check why
+            up_exc = upstream_task.exception() if not upstream_task.cancelled() else None
+            logger.warning(
+                "h2_relay_upstream_done",
+                host=self._host,
+                error=type(up_exc).__name__ if up_exc else "EOF",
+                detail=str(up_exc)[:200] if up_exc else None,
+                streams=len(self._streams),
+                pending_client=len(self._client_pending),
+            )
             client_task.cancel()
             try:
                 await client_task
@@ -293,8 +306,18 @@ class H2ConnectionHandler:
         while True:
             data = await reader.read(65536)
             if not data:
+                logger.warning("h2_client_eof", host=self._host)
                 return
-            events = self._client_conn.receive_data(data)
+            try:
+                events = self._client_conn.receive_data(data)
+            except Exception as exc:
+                logger.error(
+                    "h2_client_receive_error",
+                    host=self._host,
+                    error=type(exc).__name__,
+                    detail=str(exc)[:200],
+                )
+                return
             for event in events:
                 await self._handle_client_event(event)
             await self._flush_client()
@@ -305,8 +328,18 @@ class H2ConnectionHandler:
         while True:
             data = await self._upstream_reader.read(65536)
             if not data:
+                logger.warning("h2_upstream_eof", host=self._host)
                 return
-            events = self._upstream_conn.receive_data(data)
+            try:
+                events = self._upstream_conn.receive_data(data)
+            except Exception as exc:
+                logger.error(
+                    "h2_upstream_receive_error",
+                    host=self._host,
+                    error=type(exc).__name__,
+                    detail=str(exc)[:200],
+                )
+                return
             for event in events:
                 await self._handle_upstream_event(event)
             await self._flush_upstream()

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -69,6 +69,15 @@ class _StreamState:
     skip_scan: bool = False
 
 
+@dataclass
+class _QueuedRequest:
+    """A scanned request waiting for an upstream stream slot."""
+
+    client_stream_id: int
+    headers: list[tuple[str, str]]
+    body: bytes
+
+
 class H2ConnectionHandler:
     """Handles HTTP/2 relay between client and upstream through the MITM tunnel."""
 
@@ -100,6 +109,8 @@ class H2ConnectionHandler:
         # Pending outbound data blocked by flow control (stream_id -> (bytes, end_stream))
         self._client_pending: dict[int, tuple[bytes, bool]] = {}
         self._upstream_pending: dict[int, tuple[bytes, bool]] = {}
+        # Requests queued because upstream MAX_CONCURRENT_STREAMS was reached
+        self._queued_requests: list[_QueuedRequest] = []
 
     @staticmethod
     def _apply_window_settings(conn: h2.connection.H2Connection) -> None:
@@ -125,6 +136,7 @@ class H2ConnectionHandler:
         self._upstream_to_client.clear()
         self._client_pending.clear()
         self._upstream_pending.clear()
+        self._queued_requests.clear()
 
     def _make_h2_ssl_context(self) -> ssl.SSLContext:
         """Create a fresh SSL context with h2 ALPN, without mutating the shared one."""
@@ -470,24 +482,58 @@ class H2ConnectionHandler:
             else:
                 new_headers.append((n, v))
 
-        # Forward to upstream
-        upstream_stream_id = self._upstream_conn.get_next_available_stream_id()
+        # Forward to upstream — queue if MAX_CONCURRENT_STREAMS reached
+        if not self._forward_to_upstream(stream_id, new_headers, scanned_body):
+            # Stream limit reached — queue for later
+            self._queued_requests.append(
+                _QueuedRequest(client_stream_id=stream_id, headers=new_headers, body=scanned_body)
+            )
+            logger.debug(
+                "h2_request_queued",
+                host=self._host,
+                client_stream=stream_id,
+                queue_depth=len(self._queued_requests),
+            )
+
+    def _forward_to_upstream(
+        self, client_stream_id: int, headers: list[tuple[str, str]], body: bytes
+    ) -> bool:
+        """Try to forward a request to upstream. Returns False if stream limit reached."""
+        try:
+            upstream_stream_id = self._upstream_conn.get_next_available_stream_id()
+        except h2.exceptions.NoAvailableStreamIDError:
+            return False
+
+        state = self._streams.get(client_stream_id)
+        if state is None:
+            return True  # stream was reset while queued — discard silently
+
+        try:
+            self._upstream_conn.send_headers(
+                upstream_stream_id, headers, end_stream=(len(body) == 0)
+            )
+        except h2.exceptions.TooManyStreamsError:
+            return False
+
         state.upstream_stream_id = upstream_stream_id
-        self._upstream_to_client[upstream_stream_id] = stream_id
+        self._upstream_to_client[upstream_stream_id] = client_stream_id
 
-        send_end_stream = len(scanned_body) == 0
-        self._upstream_conn.send_headers(
-            upstream_stream_id,
-            new_headers,
-            end_stream=send_end_stream,
-        )
-
-        if scanned_body:
+        if body:
             remaining, es = self._send_data_with_flow_control(
-                self._upstream_conn, upstream_stream_id, scanned_body, end_stream=True
+                self._upstream_conn, upstream_stream_id, body, end_stream=True
             )
             if remaining:
                 self._upstream_pending[upstream_stream_id] = (remaining, es)
+
+        return True
+
+    def _drain_queued_requests(self) -> None:
+        """Send queued requests when upstream stream slots free up."""
+        while self._queued_requests:
+            req = self._queued_requests[0]
+            if not self._forward_to_upstream(req.client_stream_id, req.headers, req.body):
+                break  # still at limit
+            self._queued_requests.pop(0)
 
     # --- Upstream response handling ---
 
@@ -554,10 +600,17 @@ class H2ConnectionHandler:
                 pass  # stream already gone
             self._cleanup_stream(client_stream_id, upstream_stream_id)
 
+        # Upstream stream slot freed — send queued requests
+        self._drain_queued_requests()
+
     # --- Stream reset handling ---
 
     async def _on_client_stream_reset(self, stream_id: int) -> None:
         """Client reset a stream — propagate to upstream."""
+        # Remove from queue if it hasn't been sent yet
+        self._queued_requests = [
+            q for q in self._queued_requests if q.client_stream_id != stream_id
+        ]
         state = self._streams.get(stream_id)
         if state and state.upstream_stream_id is not None:
             try:
@@ -577,6 +630,7 @@ class H2ConnectionHandler:
             except Exception:
                 pass
             self._cleanup_stream(client_stream_id, upstream_stream_id)
+            self._drain_queued_requests()
 
     # --- Helpers ---
 

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -90,6 +90,9 @@ class H2ConnectionHandler:
         self._client_writer: asyncio.StreamWriter | None = None
         self._upstream_writer: asyncio.StreamWriter | None = None
         self._upstream_reader: asyncio.StreamReader | None = None
+        # Pending outbound data blocked by flow control (stream_id -> (bytes, end_stream))
+        self._client_pending: dict[int, tuple[bytes, bool]] = {}
+        self._upstream_pending: dict[int, tuple[bytes, bool]] = {}
 
     def _init_upstream_h2(self) -> None:
         """Create a fresh upstream h2 connection state machine."""
@@ -98,6 +101,8 @@ class H2ConnectionHandler:
         )
         self._streams.clear()
         self._upstream_to_client.clear()
+        self._client_pending.clear()
+        self._upstream_pending.clear()
 
     def _make_h2_ssl_context(self) -> ssl.SSLContext:
         """Create a fresh SSL context with h2 ALPN, without mutating the shared one."""
@@ -296,7 +301,8 @@ class H2ConnectionHandler:
             await self._on_client_stream_reset(event.stream_id)
 
         elif isinstance(event, h2.events.WindowUpdated):
-            pass
+            # Client sent WINDOW_UPDATE — flush pending response data
+            self._drain_pending(self._client_conn, self._client_pending, event.stream_id)
 
         elif isinstance(event, h2.events.ConnectionTerminated):
             logger.debug("h2_client_goaway", host=self._host)
@@ -317,7 +323,8 @@ class H2ConnectionHandler:
             await self._on_upstream_stream_reset(event.stream_id)
 
         elif isinstance(event, h2.events.WindowUpdated):
-            pass
+            # Upstream sent WINDOW_UPDATE — flush pending request data
+            self._drain_pending(self._upstream_conn, self._upstream_pending, event.stream_id)
 
         elif isinstance(event, h2.events.ConnectionTerminated):
             logger.debug("h2_upstream_goaway", host=self._host)
@@ -417,9 +424,11 @@ class H2ConnectionHandler:
         )
 
         if scanned_body:
-            self._send_data_with_flow_control(
+            remaining, es = self._send_data_with_flow_control(
                 self._upstream_conn, upstream_stream_id, scanned_body, end_stream=True
             )
+            if remaining:
+                self._upstream_pending[upstream_stream_id] = (remaining, es)
 
     # --- Upstream response handling ---
 
@@ -451,10 +460,18 @@ class H2ConnectionHandler:
         # Acknowledge upstream data
         self._upstream_conn.acknowledge_received_data(flow_controlled_length, upstream_stream_id)
 
+        # If there's already pending data for this stream, just append
+        if client_stream_id in self._client_pending:
+            existing, es = self._client_pending[client_stream_id]
+            self._client_pending[client_stream_id] = (existing + data, es)
+            return
+
         # Forward to client
-        self._send_data_with_flow_control(
+        remaining, es = self._send_data_with_flow_control(
             self._client_conn, client_stream_id, data, end_stream=False
         )
+        if remaining:
+            self._client_pending[client_stream_id] = (remaining, es)
 
     async def _on_response_complete(self, upstream_stream_id: int) -> None:
         """Upstream finished sending response (END_STREAM)."""
@@ -462,10 +479,13 @@ class H2ConnectionHandler:
         if client_stream_id is None:
             return
 
-        self._client_conn.end_stream(client_stream_id)
-
-        # Cleanup
-        self._cleanup_stream(client_stream_id, upstream_stream_id)
+        if client_stream_id in self._client_pending:
+            # Pending data still buffered — mark end_stream for when drain completes
+            data, _ = self._client_pending[client_stream_id]
+            self._client_pending[client_stream_id] = (data, True)
+        else:
+            self._client_conn.end_stream(client_stream_id)
+            self._cleanup_stream(client_stream_id, upstream_stream_id)
 
     # --- Stream reset handling ---
 
@@ -497,6 +517,35 @@ class H2ConnectionHandler:
         """Remove stream tracking state."""
         self._streams.pop(client_stream_id, None)
         self._upstream_to_client.pop(upstream_stream_id, None)
+        self._client_pending.pop(client_stream_id, None)
+        self._upstream_pending.pop(upstream_stream_id, None)
+
+    def _drain_pending(
+        self,
+        conn: h2.connection.H2Connection,
+        pending: dict[int, tuple[bytes, bool]],
+        stream_id: int,
+    ) -> None:
+        """Flush pending data after a WindowUpdated event.
+
+        stream_id=0 is a connection-level update — try all pending streams.
+        """
+        targets = list(pending.keys()) if stream_id == 0 else [stream_id]
+        for sid in targets:
+            if sid not in pending:
+                continue
+            data, end_stream = pending[sid]
+            remaining, es = self._send_data_with_flow_control(conn, sid, data, end_stream)
+            if remaining:
+                pending[sid] = (remaining, es)
+            else:
+                del pending[sid]
+                # If this was client-side pending with end_stream, cleanup the stream
+                if end_stream and pending is self._client_pending:
+                    # end_stream was already sent by _send_data_with_flow_control
+                    state = self._streams.get(sid)
+                    if state and state.upstream_stream_id is not None:
+                        self._cleanup_stream(sid, state.upstream_stream_id)
 
     def _send_data_with_flow_control(
         self,
@@ -504,28 +553,23 @@ class H2ConnectionHandler:
         stream_id: int,
         data: bytes,
         end_stream: bool,
-    ) -> None:
+    ) -> tuple[bytes, bool]:
         """Send data respecting h2 flow control windows.
 
-        Sends as much data as the flow control window allows. If the window
-        is exhausted, remaining data is silently dropped — the reader loops
-        will process WINDOW_UPDATE events and the peer will retransmit or
-        the connection will be reset. For typical API request/response sizes
-        (< 64KB) this is not an issue since the default window is 64KB.
+        Returns (unsent_data, pending_end_stream). If unsent_data is non-empty,
+        the caller must buffer it and retry when a WindowUpdated event arrives.
         """
         offset = 0
         while offset < len(data):
             window = conn.local_flow_control_window(stream_id)
             if window <= 0:
-                # Window exhausted — send end_stream on a zero-length frame if needed
-                if end_stream:
-                    conn.send_data(stream_id, b"", end_stream=True)
-                break
+                return data[offset:], end_stream
             max_size = min(window, conn.max_outbound_frame_size)
             chunk = data[offset : offset + max_size]
             is_last = (offset + len(chunk) >= len(data)) and end_stream
             conn.send_data(stream_id, chunk, end_stream=is_last)
             offset += len(chunk)
+        return b"", False
 
     async def _send_client_error(
         self,
@@ -545,7 +589,11 @@ class H2ConnectionHandler:
             ("content-length", str(len(error_body))),
         ]
         self._client_conn.send_headers(stream_id, response_headers)
-        self._send_data_with_flow_control(self._client_conn, stream_id, error_body, end_stream=True)
+        remaining, es = self._send_data_with_flow_control(
+            self._client_conn, stream_id, error_body, end_stream=True
+        )
+        if remaining:
+            self._client_pending[stream_id] = (remaining, es)
         await self._flush_client()
 
         # Cleanup — no upstream stream was created

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 import h2.config
 import h2.connection
 import h2.events
+import h2.settings
 import structlog
 
 from secretgate.scan import BlockedError, TextScanner
@@ -23,6 +24,11 @@ logger = structlog.get_logger()
 
 # Match forward.py's limit
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10MB
+
+# H2 flow control: default 65,535 bytes is far too small for proxying
+# resource-heavy pages with many concurrent streams. Production proxies
+# (nginx, envoy) use multi-MB windows. 16MB matches Go's default.
+H2_WINDOW_SIZE = 16 * 1024 * 1024  # 16MB
 
 # Auth path pattern — same as forward.py (duplicated to avoid circular import)
 _AUTH_PATH_PATTERNS = re.compile(
@@ -94,6 +100,21 @@ class H2ConnectionHandler:
         self._client_pending: dict[int, tuple[bytes, bool]] = {}
         self._upstream_pending: dict[int, tuple[bytes, bool]] = {}
 
+    @staticmethod
+    def _apply_window_settings(conn: h2.connection.H2Connection) -> None:
+        """Set large flow control windows after initiate_connection().
+
+        The default 64KB window is far too small for proxying heavy pages.
+        We increase both the per-stream initial window (via SETTINGS) and
+        the connection-level window (via WINDOW_UPDATE).
+        """
+        conn.update_settings(
+            {
+                h2.settings.SettingCodes.INITIAL_WINDOW_SIZE: H2_WINDOW_SIZE,
+            }
+        )
+        conn.increment_flow_control_window(H2_WINDOW_SIZE - 65535)
+
     def _init_upstream_h2(self) -> None:
         """Create a fresh upstream h2 connection state machine."""
         self._upstream_conn = h2.connection.H2Connection(
@@ -139,6 +160,7 @@ class H2ConnectionHandler:
 
         self._init_upstream_h2()
         self._upstream_conn.initiate_connection()
+        self._apply_window_settings(self._upstream_conn)
         await self._flush_upstream()
         return True
 
@@ -153,6 +175,7 @@ class H2ConnectionHandler:
         """
         self._client_writer = client_writer
         self._client_conn.initiate_connection()
+        self._apply_window_settings(self._client_conn)
         await self._flush_client()
 
         if not await self._connect_upstream():
@@ -173,10 +196,12 @@ class H2ConnectionHandler:
         self._upstream_writer = upstream_writer
 
         self._client_conn.initiate_connection()
+        self._apply_window_settings(self._client_conn)
         await self._flush_client()
 
         self._init_upstream_h2()
         self._upstream_conn.initiate_connection()
+        self._apply_window_settings(self._upstream_conn)
         await self._flush_upstream()
 
         await self._relay_loop(client_reader)
@@ -453,12 +478,13 @@ class H2ConnectionHandler:
         self, upstream_stream_id: int, data: bytes, flow_controlled_length: int
     ) -> None:
         """Upstream sent response body data — relay to client."""
+        # Always acknowledge to keep the connection-level flow control window open,
+        # even if the stream was already cleaned up (race with reset/complete).
+        self._upstream_conn.acknowledge_received_data(flow_controlled_length, upstream_stream_id)
+
         client_stream_id = self._upstream_to_client.get(upstream_stream_id)
         if client_stream_id is None:
             return
-
-        # Acknowledge upstream data
-        self._upstream_conn.acknowledge_received_data(flow_controlled_length, upstream_stream_id)
 
         # If there's already pending data for this stream, just append
         if client_stream_id in self._client_pending:

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -245,28 +245,12 @@ class H2ConnectionHandler:
                 except (asyncio.CancelledError, Exception):
                     pass
                 exc = client_task.exception()
-                logger.warning(
-                    "h2_relay_client_done",
-                    host=self._host,
-                    error=type(exc).__name__ if exc else None,
-                    streams=len(self._streams),
-                )
                 if exc and not isinstance(
                     exc, (ConnectionResetError, BrokenPipeError, asyncio.CancelledError)
                 ):
                     raise exc
                 return
 
-            # Upstream task completed — check why
-            up_exc = upstream_task.exception() if not upstream_task.cancelled() else None
-            logger.warning(
-                "h2_relay_upstream_done",
-                host=self._host,
-                error=type(up_exc).__name__ if up_exc else "EOF",
-                detail=str(up_exc)[:200] if up_exc else None,
-                streams=len(self._streams),
-                pending_client=len(self._client_pending),
-            )
             client_task.cancel()
             try:
                 await client_task
@@ -318,12 +302,11 @@ class H2ConnectionHandler:
         while True:
             data = await reader.read(65536)
             if not data:
-                logger.warning("h2_client_eof", host=self._host)
                 return
             try:
                 events = self._client_conn.receive_data(data)
             except Exception as exc:
-                logger.error(
+                logger.debug(
                     "h2_client_receive_error",
                     host=self._host,
                     error=type(exc).__name__,
@@ -340,12 +323,11 @@ class H2ConnectionHandler:
         while True:
             data = await self._upstream_reader.read(65536)
             if not data:
-                logger.warning("h2_upstream_eof", host=self._host)
                 return
             try:
                 events = self._upstream_conn.receive_data(data)
             except Exception as exc:
-                logger.error(
+                logger.debug(
                     "h2_upstream_receive_error",
                     host=self._host,
                     error=type(exc).__name__,

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 import h2.config
 import h2.connection
 import h2.events
+import h2.exceptions
 import h2.settings
 import structlog
 
@@ -472,7 +473,11 @@ class H2ConnectionHandler:
             v = value.decode("utf-8") if isinstance(value, bytes) else value
             decoded.append((n, v))
 
-        self._client_conn.send_headers(client_stream_id, decoded)
+        try:
+            self._client_conn.send_headers(client_stream_id, decoded)
+        except (h2.exceptions.StreamClosedError, h2.exceptions.ProtocolError):
+            logger.debug("h2_stream_closed_on_headers", stream_id=client_stream_id)
+            self._cleanup_stream(client_stream_id, upstream_stream_id)
 
     async def _on_response_data(
         self, upstream_stream_id: int, data: bytes, flow_controlled_length: int
@@ -510,7 +515,10 @@ class H2ConnectionHandler:
             data, _ = self._client_pending[client_stream_id]
             self._client_pending[client_stream_id] = (data, True)
         else:
-            self._client_conn.end_stream(client_stream_id)
+            try:
+                self._client_conn.end_stream(client_stream_id)
+            except (h2.exceptions.StreamClosedError, h2.exceptions.ProtocolError):
+                pass  # stream already gone
             self._cleanup_stream(client_stream_id, upstream_stream_id)
 
     # --- Stream reset handling ---
@@ -584,16 +592,23 @@ class H2ConnectionHandler:
 
         Returns (unsent_data, pending_end_stream). If unsent_data is non-empty,
         the caller must buffer it and retry when a WindowUpdated event arrives.
+        Returns (b"", False) if stream was closed — caller should discard.
         """
         offset = 0
         while offset < len(data):
-            window = conn.local_flow_control_window(stream_id)
+            try:
+                window = conn.local_flow_control_window(stream_id)
+            except (h2.exceptions.StreamClosedError, h2.exceptions.ProtocolError):
+                return b"", False  # stream gone, discard
             if window <= 0:
                 return data[offset:], end_stream
             max_size = min(window, conn.max_outbound_frame_size)
             chunk = data[offset : offset + max_size]
             is_last = (offset + len(chunk) >= len(data)) and end_stream
-            conn.send_data(stream_id, chunk, end_stream=is_last)
+            try:
+                conn.send_data(stream_id, chunk, end_stream=is_last)
+            except (h2.exceptions.StreamClosedError, h2.exceptions.ProtocolError):
+                return b"", False  # stream gone, discard
             offset += len(chunk)
         return b"", False
 

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -1104,6 +1104,135 @@ class TestH2Tunnel:
             echo_server.close()
             await echo_server.wait_closed()
 
+    async def test_h2_large_response_flow_control(self, ca, proxy_server):
+        """Large responses exceeding the H2 flow control window must arrive intact."""
+        _, port = proxy_server
+
+        # 200KB response — well over the default 64KB H2 window
+        echo_server, expected_body = await _run_h2_large_response_server(ca, 200_000)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer, h2_conn = await _h2_connect_and_upgrade(ca, port, echo_port)
+
+            headers = [
+                (":method", "GET"),
+                (":path", "/large"),
+                (":scheme", "https"),
+                (":authority", "127.0.0.1"),
+            ]
+            stream_id = await _h2_send_request(h2_conn, writer, headers)
+
+            status, _, body = await _h2_read_response(
+                reader, h2_conn, writer, stream_id, timeout=15.0
+            )
+            assert status == 200
+            assert len(body) == len(expected_body)
+            assert body == expected_body
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+
+async def _run_h2_large_response_server(
+    ca: CertAuthority, response_size: int, host: str = "127.0.0.1"
+):
+    """H2 server that returns a large response body, handling flow control properly."""
+    ssl_ctx = ca.get_domain_context(host)
+    # Generate deterministic response data
+    pattern = b"ABCDEFGHIJKLMNOP"  # 16 bytes
+    response_body = (pattern * (response_size // len(pattern) + 1))[:response_size]
+
+    async def handle(reader, writer):
+        config = h2.config.H2Configuration(client_side=False)
+        conn = h2.connection.H2Connection(config=config)
+        conn.initiate_connection()
+        writer.write(conn.data_to_send())
+        await writer.drain()
+
+        pending: dict[int, tuple[bytes, int]] = {}  # stream_id -> (remaining_data, offset)
+
+        try:
+            while True:
+                data = await reader.read(65536)
+                if not data:
+                    break
+
+                events = conn.receive_data(data)
+                for event in events:
+                    if isinstance(event, h2.events.RequestReceived):
+                        pass  # wait for stream end
+
+                    elif isinstance(event, h2.events.DataReceived):
+                        conn.acknowledge_received_data(
+                            event.flow_controlled_length, event.stream_id
+                        )
+
+                    elif isinstance(event, h2.events.StreamEnded):
+                        resp_headers = [
+                            (":status", "200"),
+                            ("content-type", "application/octet-stream"),
+                            ("content-length", str(len(response_body))),
+                        ]
+                        conn.send_headers(event.stream_id, resp_headers)
+                        # Send as much as flow control allows
+                        offset = 0
+                        while offset < len(response_body):
+                            window = conn.local_flow_control_window(event.stream_id)
+                            if window <= 0:
+                                pending[event.stream_id] = (response_body, offset)
+                                break
+                            chunk_size = min(
+                                window, conn.max_outbound_frame_size, len(response_body) - offset
+                            )
+                            is_last = offset + chunk_size >= len(response_body)
+                            conn.send_data(
+                                event.stream_id,
+                                response_body[offset : offset + chunk_size],
+                                end_stream=is_last,
+                            )
+                            offset += chunk_size
+                        else:
+                            pending.pop(event.stream_id, None)
+
+                    elif isinstance(event, h2.events.WindowUpdated):
+                        sid = event.stream_id
+                        targets = list(pending.keys()) if sid == 0 else [sid]
+                        for s in targets:
+                            if s not in pending:
+                                continue
+                            body_data, off = pending[s]
+                            while off < len(body_data):
+                                w = conn.local_flow_control_window(s)
+                                if w <= 0:
+                                    break
+                                cs = min(w, conn.max_outbound_frame_size, len(body_data) - off)
+                                is_last = off + cs >= len(body_data)
+                                conn.send_data(s, body_data[off : off + cs], end_stream=is_last)
+                                off += cs
+                            if off >= len(body_data):
+                                del pending[s]
+                            else:
+                                pending[s] = (body_data, off)
+
+                    elif isinstance(event, h2.events.ConnectionTerminated):
+                        writer.write(conn.data_to_send())
+                        await writer.drain()
+                        return
+
+                writer.write(conn.data_to_send())
+                await writer.drain()
+        except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
+            pass
+        finally:
+            if not writer.is_closing():
+                writer.close()
+
+    server = await asyncio.start_server(handle, host, 0, ssl=ssl_ctx)
+    return server, response_body
+
 
 async def _run_websocket_echo_server(ca: CertAuthority, host: str = "127.0.0.1"):
     """HTTPS server that accepts WebSocket upgrades and echoes one message back."""


### PR DESCRIPTION
## Summary

Fixes H2 forward proxy failures on resource-heavy pages (ERR_HTTP2_PROTOCOL_ERROR). Four root causes found and fixed:

- **Queue requests when upstream `MAX_CONCURRENT_STREAMS` is reached** — postfinance.ch allows ~12 concurrent streams. The browser fires 60 requests; `send_headers` raised `TooManyStreamsError` after 12 streams, crashing the client reader and killing the entire H2 connection. Now queues excess requests and drains when upstream stream slots free up.
- **Buffer response data on flow control backpressure** — `_send_data_with_flow_control()` was silently dropping data when the outbound flow control window was exhausted. Now buffers per-stream and flushes on `WindowUpdated` events.
- **Increase flow control windows to 16MB** — default 64KB connection-level window is far too small for proxying heavy pages with many concurrent streams. Now sends SETTINGS + WINDOW_UPDATE on init (matching Go/nginx defaults).
- **Catch per-stream h2 exceptions** — `StreamClosedError` from a single reset stream was propagating up, crashing the upstream reader task, which the relay loop treated as "upstream disconnected" — resetting ALL in-flight streams. Now handled per-stream.

Also fixes: always call `acknowledge_received_data` even for cleaned-up streams (prevents connection-level window leak).

Fixes #61

## Test plan

- [x] `test_h2_large_response_flow_control` — 200KB response (3x default H2 window) arrives intact
- [x] All existing H2 tests pass (echo, redaction, block mode, auth skip, reconnect)
- [x] Local stress test: 50 concurrent H2 streams with 30KB–200KB responses — 50/50 pass
- [x] Live test: www.postfinance.ch — 70/70 succeeded (was 12/60), Unblu chat widget loads
- [x] Full test suite passes (306 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)