### PR TITLE
fix: exclude request's own auth token from body scanning

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -524,9 +524,21 @@ class _ConnectionHandler:
             skip_scan = self._is_auth_path(req_path)
             if skip_scan:
                 logger.debug("forward_skip_auth_path", host=host, path=req_path)
+
+            # Extract auth token so we never redact the request's own
+            # credential when it also appears in the body (issue #64).
+            exclude_values: set[str] = set()
+            auth_header = req_headers.get("authorization", "")
+            if auth_header:
+                # Strip "Bearer " / "Basic " prefix to get the raw token
+                parts = auth_header.split(None, 1)
+                exclude_values.add(parts[-1] if parts else auth_header)
+
             if body and content_length > 0 and not skip_scan:
                 try:
-                    scanned_body, alerts = self._scanner.scan_body(body, content_type)
+                    scanned_body, alerts = self._scanner.scan_body(
+                        body, content_type, exclude_values=exclude_values
+                    )
                     for alert in alerts:
                         logger.warning("forward_proxy_alert", host=host, alert=alert)
                 except BlockedError as exc:

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -442,11 +442,22 @@ class H2ConnectionHandler:
                 content_type = v
                 break
 
+        # Extract auth token so we never redact the request's own
+        # credential when it also appears in the body (issue #64).
+        exclude_values: set[str] = set()
+        for n, v in headers:
+            if n == "authorization" and v:
+                parts = v.split(None, 1)
+                exclude_values.add(parts[-1] if parts else v)
+                break
+
         # Scan the request body
         scanned_body = body
         if body and not state.skip_scan:
             try:
-                scanned_body, alerts = self._scanner.scan_body(body, content_type)
+                scanned_body, alerts = self._scanner.scan_body(
+                    body, content_type, exclude_values=exclude_values
+                )
                 for alert in alerts:
                     logger.warning("h2_forward_proxy_alert", host=self._host, alert=alert)
             except BlockedError as exc:

--- a/src/secretgate/scan.py
+++ b/src/secretgate/scan.py
@@ -110,12 +110,22 @@ class TextScanner:
             alerts,
         )
 
-    def scan_body(self, body: bytes, content_type: str = "text/plain") -> tuple[bytes, list[str]]:
+    def scan_body(
+        self,
+        body: bytes,
+        content_type: str = "text/plain",
+        exclude_values: set[str] | None = None,
+    ) -> tuple[bytes, list[str]]:
         """Scan body bytes for secrets. Returns (possibly modified body, alerts).
 
         In block mode, raises BlockedError if secrets are found.
         In audit mode, returns body unchanged but with alerts.
         In redact mode, replaces secrets with [REDACTED] markers.
+
+        ``exclude_values`` — secret values to ignore (e.g. the request's own
+        Authorization token).  If a match's value is contained in any of the
+        exclude strings it is silently dropped so the proxy never corrupts a
+        request by redacting its own auth credential.
         """
         alerts: list[str] = []
 
@@ -138,6 +148,14 @@ class TextScanner:
         scannable = self._strip_model_content(text) if "json" in ct else text
 
         matches = self._scanner.scan(scannable)
+
+        # Drop matches whose value is part of the request's own auth token.
+        # This prevents redacting a legitimate OAuth/JWT credential that the
+        # app intentionally includes in the body (e.g. Cloudflare wrangler
+        # deploy multipart metadata).
+        if matches and exclude_values:
+            matches = [m for m in matches if not any(m.value in ev for ev in exclude_values)]
+
         if not matches:
             return body, alerts
 

--- a/src/secretgate/scan.py
+++ b/src/secretgate/scan.py
@@ -149,12 +149,18 @@ class TextScanner:
 
         matches = self._scanner.scan(scannable)
 
-        # Drop matches whose value is part of the request's own auth token.
-        # This prevents redacting a legitimate OAuth/JWT credential that the
-        # app intentionally includes in the body (e.g. Cloudflare wrangler
-        # deploy multipart metadata).
+        # Drop matches that ARE the request's own auth token (not just any
+        # substring).  A match is considered "the same credential" when it
+        # covers ≥50 % of an exclude value's length — this allows partial
+        # regex captures (e.g. JWT pattern grabbing 2 of 3 segments) while
+        # preventing a short, unrelated secret from being silently skipped
+        # just because it happens to appear inside a long token string.
         if matches and exclude_values:
-            matches = [m for m in matches if not any(m.value in ev for ev in exclude_values)]
+            matches = [
+                m
+                for m in matches
+                if not any(m.value in ev and len(m.value) >= len(ev) * 0.5 for ev in exclude_values)
+            ]
 
         if not matches:
             return body, alerts

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -639,6 +639,104 @@ class TestAuthPathSkip:
             await echo_server.wait_closed()
 
 
+class TestAuthTokenExclusion:
+    """Auth tokens in the request body should not be redacted when they match the Authorization header."""
+
+    async def test_jwt_in_body_not_redacted_when_in_auth_header(self, ca, proxy_server):
+        """A JWT that is both in the Authorization header and the body should not be redacted (issue #64)."""
+        _, port = proxy_server
+
+        echo_server = await _run_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            # Simulate wrangler deploy: JWT in both the Authorization header and the
+            # multipart body metadata.
+            jwt = b"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.sig_value_here"
+            body = b'{"metadata":{"token":"' + jwt + b'"}}'
+            inner_request = (
+                b"POST /workers/scripts/bugdrop/versions HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Authorization: Bearer " + jwt + b"\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            # The JWT should NOT be redacted — it's the request's own auth token
+            assert jwt in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+    async def test_other_secrets_still_redacted_with_auth_header(self, ca, proxy_server):
+        """Unrelated secrets in the body should still be redacted even when an auth header is present."""
+        _, port = proxy_server
+
+        echo_server = await _run_echo_https_server(ca)
+        echo_port = echo_server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+            connect_req = (
+                f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\nHost: 127.0.0.1:{echo_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(ssl_ctx, server_hostname="127.0.0.1")
+
+            jwt = b"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.sig_value_here"
+            body = b"leaked_key=AKIAIOSFODNN7EXAMPLE"
+            inner_request = (
+                b"POST /v1/deploy HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Authorization: Bearer " + jwt + b"\r\n"
+                b"Content-Type: application/x-www-form-urlencoded\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body
+            )
+            writer.write(inner_request)
+            await writer.drain()
+
+            inner_response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 OK" in inner_response
+            # AWS key should still be redacted
+            assert b"AKIAIOSFODNN7EXAMPLE" not in inner_response
+
+            writer.close()
+        finally:
+            echo_server.close()
+            await echo_server.wait_closed()
+
+
 class TestErrorResponses:
     async def test_502_when_upstream_drops_connection(self, ca, proxy_server):
         """Proxy should send 502 instead of EOF when upstream drops the connection."""

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -109,6 +109,33 @@ class TestScanBody:
         assert b"REDACTED<" in result
         assert len(alerts) > 0
 
+    def test_exclude_values_skips_auth_token(self, redact_scanner):
+        """A JWT that matches the request's own Authorization header should not be redacted."""
+        jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.sig_value_here"
+        body = f'{{"metadata":{{"token":"{jwt}"}}}}'.encode()
+        # Without exclusion — JWT gets redacted
+        result_no_excl, alerts_no_excl = redact_scanner.scan_body(body, "application/json")
+        assert jwt.encode() not in result_no_excl
+        assert len(alerts_no_excl) > 0
+
+        # With exclusion — JWT passes through
+        result_excl, alerts_excl = redact_scanner.scan_body(
+            body, "application/json", exclude_values={jwt}
+        )
+        assert result_excl == body
+        assert alerts_excl == []
+
+    def test_exclude_values_still_catches_other_secrets(self, redact_scanner):
+        """Excluding the auth token should not suppress unrelated secrets."""
+        jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.sig_value_here"
+        # Use JSON format so entropy scanner doesn't create overlapping matches
+        body = f'{{"auth":"{jwt}","aws_key":"AKIAIOSFODNN7EXAMPLE"}}'.encode()
+        result, alerts = redact_scanner.scan_body(body, "application/json", exclude_values={jwt})
+        # JWT passes through, AWS key still redacted
+        assert jwt.encode() in result
+        assert b"AKIAIOSFODNN7EXAMPLE" not in result
+        assert len(alerts) > 0
+
 
 # ---------------------------------------------------------------------------
 # Format detection and stripping tests

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -136,6 +136,24 @@ class TestScanBody:
         assert b"AKIAIOSFODNN7EXAMPLE" not in result
         assert len(alerts) > 0
 
+    def test_exclude_values_short_substring_not_suppressed(self, redact_scanner):
+        """A short secret that is a substring of the auth token must still be caught.
+
+        This guards against exfiltration via embedding a stolen secret inside
+        a crafted auth token.
+        """
+        # Construct a long fake auth token that embeds an AWS key as a substring
+        aws_key = "AKIAIOSFODNN7EXAMPLE"
+        long_token = f"prefix_{aws_key}_suffix_padding_to_make_it_very_long_token_value"
+        body = f'{{"key":"{aws_key}"}}'.encode()
+        result, alerts = redact_scanner.scan_body(
+            body, "application/json", exclude_values={long_token}
+        )
+        # AWS key is <50% of the long token, so it must NOT be excluded
+        assert b"AKIAIOSFODNN7EXAMPLE" not in result
+        assert b"REDACTED<" in result
+        assert len(alerts) > 0
+
 
 # ---------------------------------------------------------------------------
 # Format detection and stripping tests


### PR DESCRIPTION
## Summary

Fixes #64 — Cloudflare Wrangler deploy fails through proxy due to token corruption.

- When a request's `Authorization` header contains a JWT/OAuth token that also appears in the body (e.g. Cloudflare wrangler deploy multipart metadata), the scanner now skips that match instead of redacting it
- Extracts the bearer token from the `Authorization` header and passes it as an `exclude_values` set to `scan_body()`
- Applied to both HTTP/1.1 (`forward.py`) and HTTP/2 (`h2_handler.py`) relay paths
- Unrelated secrets in the body are still detected and redacted normally

## Test plan

- [x] Unit tests: `scan_body()` with `exclude_values` — JWT excluded, other secrets still caught
- [x] Integration tests: CONNECT tunnel with auth header — JWT in body preserved, AWS key still redacted
- [x] Full test suite: 310 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)