### PR TITLE
fix: track upstream-issued JWTs to avoid redacting echoed session tokens

### DIFF
--- a/src/secretgate/forward.py
+++ b/src/secretgate/forward.py
@@ -17,7 +17,12 @@ import structlog
 
 from secretgate.certs import CertAuthority
 from secretgate.h2_handler import H2ConnectionHandler
-from secretgate.scan import BlockedError, TextScanner
+from secretgate.scan import (
+    BlockedError,
+    SessionTokenHarvester,
+    TextScanner,
+    get_session_tokens,
+)
 
 logger = structlog.get_logger()
 
@@ -196,6 +201,22 @@ class _ConnectionHandler:
     def _is_auth_path(path: str) -> bool:
         """Return True if the request path is an auth/token endpoint that should skip scanning."""
         return bool(_AUTH_PATH_PATTERNS.search(path))
+
+    @staticmethod
+    def _harvest(harvester: SessionTokenHarvester, data: bytes) -> None:
+        """Feed response body data to the session-token harvester.
+
+        The harvester buffers decompressed data and scans on ``close()``
+        so JWTs spanning chunk boundaries are caught reliably.
+        """
+        harvester.feed(data)
+
+    @staticmethod
+    def _harvest_flush(harvester: SessionTokenHarvester) -> None:
+        """Flush the harvester at end-of-response and emit a diagnostic log."""
+        added = harvester.close()
+        if added:
+            logger.info("session_token_harvested", host=harvester._host, count=added)
 
     async def run(self) -> None:
         """Read the initial request and dispatch."""
@@ -527,7 +548,11 @@ class _ConnectionHandler:
 
             # Extract auth token so we never redact the request's own
             # credential when it also appears in the body (issue #64).
-            exclude_values: set[str] = set()
+            # Also include session tokens previously seen in upstream
+            # responses to the same host (issue #66).
+            exclude_values: set[str] = get_session_tokens(host)
+            if exclude_values:
+                logger.info("session_tokens_loaded", host=host, count=len(exclude_values))
             auth_header = req_headers.get("authorization", "")
             if auth_header:
                 # Strip "Bearer " / "Basic " prefix to get the raw token
@@ -690,31 +715,51 @@ class _ConnectionHandler:
             transfer_encoding = resp_headers.get("transfer-encoding", "").lower()
             resp_content_length = resp_headers.get("content-length")
             connection = resp_headers.get("connection", "").lower()
+            resp_content_encoding = resp_headers.get("content-encoding", "")
 
+            # Harvester for JWT-shaped session tokens issued by the upstream.
+            # Decompresses gzip/deflate before pattern matching so Cloudflare-
+            # style gzipped JSON responses are handled correctly (issue #66).
+            #
+            # Important: do NOT feed ``resp_body_start`` here.  For a chunked
+            # response it contains raw chunk-size prefixes that would corrupt
+            # the zlib decompressor's state and permanently disable harvesting
+            # for the rest of the response.  Each framing branch below feeds
+            # the right bytes: fixed-length / read-until-close use raw entity
+            # bytes; the chunked branch uses h11-decoded ``Data.data``.
+            harvester = SessionTokenHarvester(host, resp_content_encoding)
+
+            # Relay the body-start bytes to the client unchanged — they were
+            # read as part of the header buffer but belong to the body.
             if resp_body_start:
                 client_writer.write(resp_body_start)
                 await client_writer.drain()
 
             if resp_content_length is not None:
-                # Fixed-length body
+                # Fixed-length body: ``resp_body_start`` is pure entity bytes
+                # (possibly gzip-framed), so feed it to the harvester.
+                if resp_body_start:
+                    self._harvest(harvester, resp_body_start)
                 cl = int(resp_content_length)
                 sent = len(resp_body_start)
                 while sent < cl:
                     remaining = cl - sent
                     chunk = await upstream_reader.read(min(remaining, 65536))
                     if not chunk:
+                        self._harvest_flush(harvester)
                         return
+                    self._harvest(harvester, chunk)
                     client_writer.write(chunk)
                     await client_writer.drain()
                     sent += len(chunk)
+                self._harvest_flush(harvester)
             elif "chunked" in transfer_encoding:
-                # Use h11 to properly detect end of chunked response stream.
-                # h11 tracks chunk framing and emits EndOfMessage at the terminal chunk.
+                # Use h11 to both detect end-of-stream AND decode the chunk
+                # framing.  The harvester is fed only decoded ``Data.data``
+                # payloads (pure entity bytes, possibly gzip-framed) — raw
+                # socket bytes are left to the client relay.
                 resp_conn = h11.Connection(our_role=h11.CLIENT)
-                # Put h11 in the correct state by telling it we "sent" a request
                 method_str = request_line.split(" ", 1)[0]
-                # Only include headers h11 needs for response parsing (host).
-                # Exclude body-framing headers so h11 doesn't expect request body data.
                 skip_headers = {"content-length", "transfer-encoding", "content-type"}
                 h11_headers = [
                     (k.encode("latin-1"), v.encode("latin-1"))
@@ -730,12 +775,18 @@ class _ConnectionHandler:
                 )
                 resp_conn.send(h11.EndOfMessage())
 
-                # Feed the response data we already have (headers + any body start)
+                # Feed the full header buffer to h11 — this also seeds it
+                # with any body-start bytes that were read along with the
+                # headers.  Drain any ``Data`` events that are already
+                # available into the harvester before blocking on the socket.
                 resp_conn.receive_data(resp_header_data)
                 resp_done = False
                 while True:
                     ev = resp_conn.next_event()
-                    if isinstance(ev, (h11.Response, h11.InformationalResponse, h11.Data)):
+                    if isinstance(ev, h11.Data):
+                        self._harvest(harvester, ev.data)
+                        continue
+                    elif isinstance(ev, (h11.Response, h11.InformationalResponse)):
                         continue
                     elif isinstance(ev, h11.EndOfMessage):
                         resp_done = True
@@ -748,6 +799,7 @@ class _ConnectionHandler:
                 while not resp_done:
                     chunk = await upstream_reader.read(65536)
                     if not chunk:
+                        self._harvest_flush(harvester)
                         return
                     client_writer.write(chunk)
                     await client_writer.drain()
@@ -755,6 +807,7 @@ class _ConnectionHandler:
                     while True:
                         ev = resp_conn.next_event()
                         if isinstance(ev, h11.Data):
+                            self._harvest(harvester, ev.data)
                             continue
                         elif isinstance(ev, h11.EndOfMessage):
                             resp_done = True
@@ -764,17 +817,23 @@ class _ConnectionHandler:
                         else:
                             resp_done = True
                             break
+                self._harvest_flush(harvester)
             else:
-                # No content-length, no chunked — read until connection close
+                # No content-length, no chunked — read until connection close.
+                # ``resp_body_start`` is pure entity bytes here, so feed it.
+                if resp_body_start:
+                    self._harvest(harvester, resp_body_start)
                 try:
                     while True:
                         chunk = await upstream_reader.read(65536)
                         if not chunk:
                             break
+                        self._harvest(harvester, chunk)
                         client_writer.write(chunk)
                         await client_writer.drain()
                 except (ConnectionResetError, BrokenPipeError):
                     pass
+                self._harvest_flush(harvester)
                 return  # connection is done
 
             if connection == "close":
@@ -840,7 +899,9 @@ class _ConnectionHandler:
             logger.debug("forward_skip_auth_path", host=host, path=req_path)
         if body and content_length > 0 and not skip_scan:
             try:
-                scanned_body, alerts = self._scanner.scan_body(body, content_type)
+                scanned_body, alerts = self._scanner.scan_body(
+                    body, content_type, exclude_values=get_session_tokens(host)
+                )
                 for alert in alerts:
                     logger.warning("forward_proxy_alert", host=host, alert=alert)
             except BlockedError as exc:
@@ -875,15 +936,23 @@ class _ConnectionHandler:
         up_writer.write(modified_headers + scanned_body)
         await up_writer.drain()
 
-        # Relay response back
+        # Relay response back.  Plain-HTTP forward proxy mode does not parse
+        # response headers so we don't know the Content-Encoding; create a
+        # passthrough harvester so uncompressed bodies still contribute to
+        # the per-host session-token store.  Gzipped plain-HTTP responses
+        # will be a no-op here, which is acceptable because plain HTTP is
+        # not the hot path for the issue #66 wrangler flow.
+        harvester = SessionTokenHarvester(host)
         try:
             while True:
                 chunk = await up_reader.read(65536)
                 if not chunk:
                     break
+                self._harvest(harvester, chunk)
                 self._writer.write(chunk)
                 await self._writer.drain()
         except (ConnectionResetError, BrokenPipeError):
             pass
         finally:
+            self._harvest_flush(harvester)
             up_writer.close()

--- a/src/secretgate/h2_handler.py
+++ b/src/secretgate/h2_handler.py
@@ -19,17 +19,17 @@ import h2.exceptions
 import h2.settings
 import structlog
 
-from secretgate.scan import BlockedError, TextScanner
+from secretgate.scan import (
+    BlockedError,
+    SessionTokenHarvester,
+    TextScanner,
+    get_session_tokens,
+)
 
 logger = structlog.get_logger()
 
 # Match forward.py's limit
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10MB
-
-# H2 flow control: default 65,535 bytes is far too small for proxying
-# resource-heavy pages with many concurrent streams. Production proxies
-# (nginx, envoy) use multi-MB windows. 16MB matches Go's default.
-H2_WINDOW_SIZE = 16 * 1024 * 1024  # 16MB
 
 # Auth path pattern — same as forward.py (duplicated to avoid circular import)
 _AUTH_PATH_PATTERNS = re.compile(
@@ -43,6 +43,11 @@ _AUTH_PATH_PATTERNS = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+# H2 flow control: default 65,535 bytes is far too small for proxying
+# resource-heavy pages with many concurrent streams. Production proxies
+# (nginx, envoy) use multi-MB windows. 16MB matches Go's default.
+H2_WINDOW_SIZE = 16 * 1024 * 1024  # 16MB
 
 
 def _print_block_notice(message: str, alerts: list[str], host: str) -> None:
@@ -111,6 +116,10 @@ class H2ConnectionHandler:
         self._upstream_pending: dict[int, tuple[bytes, bool]] = {}
         # Requests queued because upstream MAX_CONCURRENT_STREAMS was reached
         self._queued_requests: list[_QueuedRequest] = []
+        # Streaming JWT harvester per upstream stream.  Created when the
+        # upstream sends response headers (so we know the content-encoding)
+        # and destroyed when the response completes or the stream resets.
+        self._response_harvesters: dict[int, SessionTokenHarvester] = {}
 
     @staticmethod
     def _apply_window_settings(conn: h2.connection.H2Connection) -> None:
@@ -444,7 +453,11 @@ class H2ConnectionHandler:
 
         # Extract auth token so we never redact the request's own
         # credential when it also appears in the body (issue #64).
-        exclude_values: set[str] = set()
+        # Also include session tokens previously seen in upstream
+        # responses to the same host (issue #66).
+        exclude_values: set[str] = get_session_tokens(self._host)
+        if exclude_values:
+            logger.info("h2_session_tokens_loaded", host=self._host, count=len(exclude_values))
         for n, v in headers:
             if n == "authorization" and v:
                 parts = v.split(None, 1)
@@ -540,10 +553,20 @@ class H2ConnectionHandler:
 
         # Decode header tuples
         decoded = []
+        content_encoding = ""
         for name, value in headers:
             n = name.decode("utf-8") if isinstance(name, bytes) else name
             v = value.decode("utf-8") if isinstance(value, bytes) else value
             decoded.append((n, v))
+            if n.lower() == "content-encoding":
+                content_encoding = v
+
+        # Create a streaming JWT harvester for this response.  Cloudflare
+        # (and most APIs) return gzipped JSON, so the harvester must
+        # decompress before pattern matching (issue #66).
+        self._response_harvesters[upstream_stream_id] = SessionTokenHarvester(
+            self._host, content_encoding
+        )
 
         try:
             self._client_conn.send_headers(client_stream_id, decoded)
@@ -558,6 +581,14 @@ class H2ConnectionHandler:
         # Always acknowledge to keep the connection-level flow control window open,
         # even if the stream was already cleaned up (race with reset/complete).
         self._upstream_conn.acknowledge_received_data(flow_controlled_length, upstream_stream_id)
+
+        # Harvest JWTs the upstream issues so we don't redact them when the
+        # client echoes them back in a follow-up request body (issue #66).
+        # The harvester transparently decompresses gzip/deflate and buffers
+        # data until _on_response_complete, which scans the full response.
+        harvester = self._response_harvesters.get(upstream_stream_id)
+        if data and harvester is not None:
+            harvester.feed(data)
 
         client_stream_id = self._upstream_to_client.get(upstream_stream_id)
         if client_stream_id is None:
@@ -578,6 +609,14 @@ class H2ConnectionHandler:
 
     async def _on_response_complete(self, upstream_stream_id: int) -> None:
         """Upstream finished sending response (END_STREAM)."""
+        # Flush the streaming harvester — decompressors may hold trailing
+        # state until they see the stream end.
+        harvester = self._response_harvesters.pop(upstream_stream_id, None)
+        if harvester is not None:
+            added = harvester.close()
+            if added:
+                logger.info("h2_session_token_harvested", host=self._host, count=added)
+
         client_stream_id = self._upstream_to_client.get(upstream_stream_id)
         if client_stream_id is None:
             return
@@ -616,6 +655,8 @@ class H2ConnectionHandler:
 
     async def _on_upstream_stream_reset(self, upstream_stream_id: int) -> None:
         """Upstream reset a stream — propagate to client."""
+        # Drop any partial harvester state for this stream.
+        self._response_harvesters.pop(upstream_stream_id, None)
         client_stream_id = self._upstream_to_client.get(upstream_stream_id)
         if client_stream_id is not None:
             try:

--- a/src/secretgate/scan.py
+++ b/src/secretgate/scan.py
@@ -7,6 +7,8 @@ instead of structured JSON messages.
 from __future__ import annotations
 
 import json
+import re
+import zlib
 
 import structlog
 
@@ -15,6 +17,187 @@ from secretgate.secrets.redactor import _make_placeholder
 from secretgate.secrets.scanner import SecretScanner
 
 logger = structlog.get_logger()
+
+# JWT pattern used to extract session tokens from upstream response bodies.
+# Mirrors the JWT Token signature in signatures.yaml.  Used by the forward
+# proxy to track tokens issued by an upstream so they are not redacted when
+# the client sends them back in a subsequent request body (issue #66).
+_JWT_RE = re.compile(rb"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_./+=-]+")
+
+# Bound the per-host session-token set so a busy host cannot grow memory
+# without limit.  64 tokens per host is plenty (most APIs issue 1-3 long-lived
+# session tokens) and bounds total memory at ~64 * 64 hosts * ~2 KB each.
+MAX_SESSION_TOKENS = 64
+MAX_SESSION_HOSTS = 64
+
+# Module-level store of session tokens harvested from upstream responses,
+# keyed by host.  Shared across all forward-proxy connections so a token
+# observed on one TCP connection to host X is excluded from request scans
+# on a *different* TCP connection to the same host X.  Without this, a
+# client like wrangler that uses a connection pool would not benefit from
+# session-token tracking, because /assets-upload-session and /versions
+# could land on different sockets and therefore different handler instances.
+_SESSION_TOKENS_BY_HOST: dict[str, set[str]] = {}
+
+
+def extract_session_tokens(data: bytes) -> set[str]:
+    """Extract JWT-shaped strings from raw bytes (e.g. an upstream response body).
+
+    Used by the forward proxy to remember session tokens issued by upstream
+    servers so the same tokens are not redacted when the client echoes them
+    back in a follow-up request body.
+    """
+    if not data or b"eyJ" not in data:
+        return set()
+    return {m.group(0).decode("ascii", errors="replace") for m in _JWT_RE.finditer(data)}
+
+
+def remember_session_tokens(host: str, data: bytes) -> int:
+    """Harvest JWTs from ``data`` and remember them under ``host``.
+
+    Returns the number of new tokens added.  Bounded per-host to
+    ``MAX_SESSION_TOKENS`` and per-process to ``MAX_SESSION_HOSTS`` hosts so
+    a long-running proxy cannot grow memory without limit.
+    """
+    if not host or not data:
+        return 0
+    tokens = extract_session_tokens(data)
+    if not tokens:
+        return 0
+    bucket = _SESSION_TOKENS_BY_HOST.get(host)
+    if bucket is None:
+        if len(_SESSION_TOKENS_BY_HOST) >= MAX_SESSION_HOSTS:
+            return 0
+        bucket = set()
+        _SESSION_TOKENS_BY_HOST[host] = bucket
+    added = 0
+    for tok in tokens:
+        if len(bucket) >= MAX_SESSION_TOKENS:
+            break
+        if tok not in bucket:
+            bucket.add(tok)
+            added += 1
+    return added
+
+
+def get_session_tokens(host: str) -> set[str]:
+    """Return tokens previously harvested from ``host`` upstream responses."""
+    if not host:
+        return set()
+    bucket = _SESSION_TOKENS_BY_HOST.get(host)
+    return set(bucket) if bucket else set()
+
+
+def clear_session_tokens() -> None:
+    """Clear all harvested session tokens.  Used by tests."""
+    _SESSION_TOKENS_BY_HOST.clear()
+
+
+class SessionTokenHarvester:
+    """Streaming JWT harvester that decompresses gzip/deflate before scanning.
+
+    Cloudflare (and most APIs) return responses with ``Content-Encoding: gzip``.
+    Running the JWT regex on the compressed bytes silently finds nothing, so
+    session tokens issued by the upstream are never remembered and the same
+    tokens get redacted when the client echoes them back in a follow-up
+    request.  This class wraps a streaming decompressor so each chunk of the
+    upstream response is decompressed, then buffered, then scanned when the
+    response ends — buffering is necessary because a JWT may span multiple
+    compressed or un-compressed chunks.
+
+    A harvester is created per response (HTTP/1.1) or per stream (HTTP/2).
+    Callers:
+
+        h = SessionTokenHarvester(host, content_encoding)
+        for chunk in response_body_chunks:
+            h.feed(chunk)     # decompresses + buffers, relay chunk unmodified
+        h.close()             # decompress-flush + scan buffer, returns count
+    """
+
+    # Cap the per-response decompressed buffer so a pathological upstream
+    # cannot exhaust memory with a huge gzipped JSON body.
+    MAX_BUFFER = 1 * 1024 * 1024  # 1 MB
+
+    def __init__(self, host: str, content_encoding: str = "") -> None:
+        self._host = host
+        self._decompressor: zlib._Decompress | None = None
+        self._buffer = bytearray()
+        self._overflow = False
+        encoding = (content_encoding or "").lower().strip()
+        if encoding in ("gzip", "x-gzip", "deflate"):
+            # wbits = 32 + MAX_WBITS auto-detects gzip header vs zlib wrapper
+            # vs raw deflate, so a single path covers both encodings.
+            self._decompressor = zlib.decompressobj(32 + zlib.MAX_WBITS)
+            self._supported = True
+        elif encoding and encoding != "identity":
+            # br (brotli), zstd etc. — not supported, harvest will be a no-op
+            logger.debug(
+                "session_token_harvester_unsupported_encoding",
+                host=host,
+                encoding=encoding,
+            )
+            self._supported = False
+        else:
+            self._supported = True
+
+    def _append(self, data: bytes) -> None:
+        """Append data to the buffer, bounded by MAX_BUFFER."""
+        if self._overflow or not data:
+            return
+        room = self.MAX_BUFFER - len(self._buffer)
+        if room <= 0:
+            self._overflow = True
+            return
+        if len(data) > room:
+            self._buffer.extend(data[:room])
+            self._overflow = True
+        else:
+            self._buffer.extend(data)
+
+    def feed(self, data: bytes) -> int:
+        """Feed one chunk of the upstream response body.
+
+        Returns 0 — tokens are scanned on ``close()``.  Relay the original
+        (un-decompressed) ``data`` bytes to the client unchanged; this method
+        only observes, it never mutates.
+        """
+        if not data or not self._supported:
+            return 0
+        if self._decompressor is not None:
+            try:
+                decompressed = self._decompressor.decompress(data)
+            except zlib.error:
+                # Corrupt stream — disable further decompression on this
+                # harvester so we don't keep retrying on each chunk.
+                self._supported = False
+                return 0
+            if decompressed:
+                self._append(decompressed)
+        else:
+            self._append(data)
+        return 0
+
+    def close(self) -> int:
+        """Flush trailing state and scan the accumulated buffer.
+
+        Returns the number of new tokens added to the per-host store.
+        """
+        if not self._supported:
+            return 0
+        if self._decompressor is not None:
+            try:
+                tail = self._decompressor.flush()
+            except zlib.error:
+                tail = b""
+            if tail:
+                self._append(tail)
+        if not self._buffer:
+            return 0
+        added = remember_session_tokens(self._host, bytes(self._buffer))
+        # Release buffer memory once scanned
+        self._buffer = bytearray()
+        return added
+
 
 # Content types that should never be scanned (binary data)
 _SKIP_PREFIXES = ("image/", "audio/", "video/")

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -736,6 +736,230 @@ class TestAuthTokenExclusion:
             echo_server.close()
             await echo_server.wait_closed()
 
+    async def test_session_token_from_response_excluded_from_next_request(self, ca, proxy_server):
+        """Issue #66: a JWT issued in an upstream response must not be redacted
+        when the client echoes it back in a follow-up request body."""
+        _, port = proxy_server
+
+        jwt = b"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+
+        async def handle(reader, writer):
+            # Request 1: respond with a JSON body containing the JWT
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return
+                data += chunk
+            resp1_body = b'{"jwt":"' + jwt + b'","ok":true}'
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(resp1_body)).encode() + b"\r\n"
+                b"\r\n" + resp1_body
+            )
+            await writer.drain()
+
+            # Request 2: echo the request body so we can inspect what arrived
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return
+                data += chunk
+            header_end = data.index(b"\r\n\r\n") + 4
+            cl = 0
+            for line in data[:header_end].decode("latin-1").split("\r\n"):
+                if line.lower().startswith("content-length:"):
+                    cl = int(line.split(":", 1)[1].strip())
+                    break
+            body = data[header_end:]
+            while len(body) < cl:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                body += chunk
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n"
+                b"\r\n" + body
+            )
+            await writer.drain()
+            writer.close()
+
+        ssl_ctx = ca.get_domain_context("127.0.0.1")
+        server = await asyncio.start_server(handle, "127.0.0.1", 0, ssl=ssl_ctx)
+        srv_port = server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            connect_req = (
+                f"CONNECT 127.0.0.1:{srv_port} HTTP/1.1\r\nHost: 127.0.0.1:{srv_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            client_ssl = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            client_ssl.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(client_ssl, server_hostname="127.0.0.1")
+
+            # Request 1: GET — response carries the JWT
+            req1 = b"GET /assets-upload-session HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+            writer.write(req1)
+            await writer.drain()
+            resp1 = b""
+            while b'"ok":true}' not in resp1:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+                if not chunk:
+                    break
+                resp1 += chunk
+            assert jwt in resp1, "JWT should pass through unscanned in response"
+
+            # Request 2: POST with the JWT in the body — must NOT be redacted
+            req2_body = b'{"assets":{"jwt":"' + jwt + b'","config":{}}}'
+            req2 = (
+                b"POST /workers/scripts/test/versions HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(req2_body)).encode() + b"\r\n"
+                b"\r\n" + req2_body
+            )
+            writer.write(req2)
+            await writer.drain()
+            resp2 = b""
+            while True:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+                if not chunk:
+                    break
+                resp2 += chunk
+            # The echoed request body should contain the original JWT, not a placeholder
+            assert jwt in resp2, "JWT should be excluded from request scan after seen in response"
+            assert b"REDACTED<jwt-token" not in resp2
+
+            writer.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_session_token_from_chunked_gzip_response(self, ca, proxy_server):
+        """Issue #66: Cloudflare wrangler flow — the JWT arrives in a
+        chunked + gzip response, so the harvester must decode chunked
+        framing and decompress gzip before running the JWT regex."""
+        import gzip
+
+        _, port = proxy_server
+
+        jwt = b"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+
+        async def handle(reader, writer):
+            # Request 1: /assets-upload-session — reply with chunked + gzip
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return
+                data += chunk
+            plaintext = b'{"result":{"jwt":"' + jwt + b'"},"ok":true}'
+            gzipped = gzip.compress(plaintext)
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Encoding: gzip\r\n"
+                b"Transfer-Encoding: chunked\r\n\r\n"
+            )
+            # Split the gzip stream across two chunks so both the buffering
+            # and the streaming decompressor paths are exercised.
+            mid = len(gzipped) // 2
+            for part in (gzipped[:mid], gzipped[mid:]):
+                writer.write(f"{len(part):x}\r\n".encode() + part + b"\r\n")
+            writer.write(b"0\r\n\r\n")
+            await writer.drain()
+
+            # Request 2: /versions — echo the request body so we can inspect
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return
+                data += chunk
+            header_end = data.index(b"\r\n\r\n") + 4
+            cl = 0
+            for line in data[:header_end].decode("latin-1").split("\r\n"):
+                if line.lower().startswith("content-length:"):
+                    cl = int(line.split(":", 1)[1].strip())
+                    break
+            body = data[header_end:]
+            while len(body) < cl:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                body += chunk
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+            writer.close()
+
+        ssl_ctx = ca.get_domain_context("127.0.0.1")
+        server = await asyncio.start_server(handle, "127.0.0.1", 0, ssl=ssl_ctx)
+        srv_port = server.sockets[0].getsockname()[1]
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            connect_req = (
+                f"CONNECT 127.0.0.1:{srv_port} HTTP/1.1\r\nHost: 127.0.0.1:{srv_port}\r\n\r\n"
+            )
+            writer.write(connect_req.encode())
+            await writer.drain()
+            response = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+            assert b"200 Connection Established" in response
+
+            client_ssl = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            client_ssl.load_verify_locations(str(ca.ca_cert_path))
+            await writer.start_tls(client_ssl, server_hostname="127.0.0.1")
+
+            # Request 1: GET /assets-upload-session
+            writer.write(b"GET /assets-upload-session HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            await writer.drain()
+            resp1 = b""
+            while b"0\r\n\r\n" not in resp1:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+                if not chunk:
+                    break
+                resp1 += chunk
+
+            # Request 2: POST /versions with the JWT echoed in the body
+            req2_body = b'{"assets":{"jwt":"' + jwt + b'","config":{}}}'
+            req2 = (
+                b"POST /workers/scripts/test/versions HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(req2_body)).encode() + b"\r\n\r\n" + req2_body
+            )
+            writer.write(req2)
+            await writer.drain()
+            resp2 = b""
+            while True:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5.0)
+                if not chunk:
+                    break
+                resp2 += chunk
+            # The server echoed what it received — the JWT must be intact
+            assert jwt in resp2, "JWT must survive the /versions body scan"
+            assert b"REDACTED<jwt-token" not in resp2
+
+            writer.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+
 
 class TestErrorResponses:
     async def test_502_when_upstream_drops_connection(self, ca, proxy_server):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -8,11 +8,16 @@ import pytest
 
 from secretgate.scan import (
     BlockedError,
+    SessionTokenHarvester,
     TextScanner,
     _blank_gemini_part,
     _strip_cohere,
     _strip_gemini,
     _strip_messages_format,
+    clear_session_tokens,
+    extract_session_tokens,
+    get_session_tokens,
+    remember_session_tokens,
 )
 from secretgate.secrets.scanner import SecretScanner
 
@@ -135,6 +140,152 @@ class TestScanBody:
         assert jwt.encode() in result
         assert b"AKIAIOSFODNN7EXAMPLE" not in result
         assert len(alerts) > 0
+
+    def test_extract_session_tokens_finds_jwts_in_json(self):
+        body = (
+            b'{"jwt":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value",'
+            b'"other":"not-a-jwt"}'
+        )
+        tokens = extract_session_tokens(body)
+        assert "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value" in tokens
+
+    def test_extract_session_tokens_returns_empty_for_clean_body(self):
+        assert extract_session_tokens(b'{"hello":"world"}') == set()
+        assert extract_session_tokens(b"") == set()
+
+    def test_session_token_excluded_from_request_scan(self, redact_scanner):
+        """Simulates the issue #66 flow: a JWT issued by the upstream is
+        echoed back in a follow-up request body and must not be redacted."""
+        # Token harvested from a prior upstream response body
+        upstream_body = b'{"jwt":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"}'
+        session_tokens = extract_session_tokens(upstream_body)
+        assert session_tokens
+
+        # Subsequent request echoes the token in its multipart metadata
+        request_body = (
+            b'{"assets":{"jwt":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value",'
+            b'"config":{}}}'
+        )
+        result, alerts = redact_scanner.scan_body(
+            request_body, "application/json", exclude_values=session_tokens
+        )
+        # JWT survives — secretgate recognizes it as a session token
+        assert b"eyJhbGciOiJSUzI1NiJ9" in result
+        assert b"REDACTED<jwt-token" not in result
+        assert alerts == []
+
+    def test_remember_and_get_session_tokens_per_host(self):
+        """Tokens harvested under one host are retrievable later for that host."""
+        clear_session_tokens()
+        try:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+            body = f'{{"jwt":"{jwt}"}}'.encode()
+            added = remember_session_tokens("api.cloudflare.com", body)
+            assert added == 1
+            assert jwt in get_session_tokens("api.cloudflare.com")
+            # Other hosts must not see the token
+            assert get_session_tokens("api.github.com") == set()
+        finally:
+            clear_session_tokens()
+
+    def test_remember_session_tokens_survives_across_handlers(self, redact_scanner):
+        """Two separate handler instances on the same host share session tokens.
+
+        Simulates wrangler's connection pool: /assets-upload-session and
+        /versions land on different sockets but the same host, and the JWT
+        should still be excluded from request scanning on the second socket.
+        """
+        clear_session_tokens()
+        try:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+            # Connection 1: harvest the JWT from an upstream response
+            response_body = f'{{"result":{{"jwt":"{jwt}"}}}}'.encode()
+            remember_session_tokens("api.cloudflare.com", response_body)
+
+            # Connection 2 (different handler instance): scan a request body
+            # that echoes the JWT — should NOT redact
+            request_body = f'{{"assets":{{"jwt":"{jwt}","config":{{}}}}}}'.encode()
+            result, alerts = redact_scanner.scan_body(
+                request_body,
+                "application/json",
+                exclude_values=get_session_tokens("api.cloudflare.com"),
+            )
+            assert jwt.encode() in result
+            assert b"REDACTED<jwt-token" not in result
+            assert alerts == []
+        finally:
+            clear_session_tokens()
+
+    def test_harvester_gzip_decompresses_before_matching(self):
+        """Issue #66: Cloudflare returns gzip — harvester must decompress."""
+        import gzip
+
+        clear_session_tokens()
+        try:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+            plaintext = f'{{"result":{{"jwt":"{jwt}"}}}}'.encode()
+            gzipped = gzip.compress(plaintext)
+            # Sanity: the regex must not match the gzipped bytes directly
+            assert extract_session_tokens(gzipped) == set()
+
+            h = SessionTokenHarvester("api.cloudflare.com", "gzip")
+            h.feed(gzipped)
+            added = h.close()
+            assert added == 1
+            assert jwt in get_session_tokens("api.cloudflare.com")
+        finally:
+            clear_session_tokens()
+
+    def test_harvester_gzip_streaming_multi_chunk(self):
+        """A gzip stream split across multiple feed() calls must still work."""
+        import gzip
+
+        clear_session_tokens()
+        try:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature_value"
+            # Large enough plaintext that gzip produces several bytes
+            plaintext = (f'{{"result":{{"jwt":"{jwt}","pad":"' + "x" * 500 + '"}}}').encode()
+            gzipped = gzip.compress(plaintext)
+            # Split the gzip stream in the middle
+            mid = len(gzipped) // 2
+            part1, part2 = gzipped[:mid], gzipped[mid:]
+
+            h = SessionTokenHarvester("example.com", "gzip")
+            h.feed(part1)
+            h.feed(part2)
+            h.close()
+            assert jwt in get_session_tokens("example.com")
+        finally:
+            clear_session_tokens()
+
+    def test_harvester_identity_passthrough(self):
+        """Uncompressed (or ``identity``) responses must still harvest."""
+        clear_session_tokens()
+        try:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"
+            body = f'{{"jwt":"{jwt}"}}'.encode()
+            for encoding in ("", "identity"):
+                clear_session_tokens()
+                h = SessionTokenHarvester("example.com", encoding)
+                h.feed(body)
+                h.close()
+                assert jwt in get_session_tokens("example.com")
+        finally:
+            clear_session_tokens()
+
+    def test_harvester_unsupported_encoding_is_noop(self):
+        """Brotli / zstd responses are not supported — harvester should no-op."""
+        clear_session_tokens()
+        try:
+            body = b'{"jwt":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"}'
+            h = SessionTokenHarvester("example.com", "br")
+            # Feed random bytes — they're not real brotli but the harvester
+            # just ignores the body entirely for unsupported encodings.
+            h.feed(body)
+            h.close()
+            assert get_session_tokens("example.com") == set()
+        finally:
+            clear_session_tokens()
 
     def test_exclude_values_short_substring_not_suppressed(self, redact_scanner):
         """A short secret that is a substring of the auth token must still be caught.


### PR DESCRIPTION
## Summary

Fixes #66.  PR #67 was merged into the (now-deleted) #65 feature branch instead of main, so its content never reached main when #65 was squash-merged.  This re-targets the same commits onto current main.

Cherry-picked from 8aba5df.

## What it does

Cloudflare wrangler deploy fails after PR #65 because the JWT in the `/versions` request body is a Cloudflare-issued session token from the prior `/assets-upload-session` response — not the Authorization header bearer token that PR #65 covers.

This PR:
- Harvests JWT-shaped strings from upstream response bodies and stores them per-host (module-level dict, bounded at 64 tokens × 64 hosts)
- Decompresses gzip / deflate / x-gzip responses via streaming \`zlib.decompressobj(32+MAX_WBITS)\` before pattern matching (Cloudflare returns gzipped JSON)
- Decodes HTTP/1.1 chunked framing via h11 so the harvester sees pure entity bytes (not chunk-size prefixes that would corrupt the decompressor)
- Adds harvested values to \`exclude_values\` when scanning subsequent request bodies to the same host
- Promotes \`session_token_harvested\` and \`session_tokens_loaded\` to info-level logs so the harvest path is visible in wrap.log

## Test plan

- [x] Unit tests: \`SessionTokenHarvester\` for plain, gzip-single-feed, gzip-multi-chunk, identity, and unsupported-encoding cases
- [x] Integration test: full chunked + gzip response carrying a JWT, followed by a POST that echoes the JWT in the body — the proxy must preserve it
- [x] Cross-handler test: harvest on one connection, exclusion check on another — both must see the same per-host store
- [x] Full test suite (322 tests) passes
- [x] Verified live: \`wrangler deploy\` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)