### PR TITLE
fix: skip scanning binary image/document data in LLM API requests

### DIFF
--- a/src/secretgate/scan.py
+++ b/src/secretgate/scan.py
@@ -409,6 +409,69 @@ class TextScanner:
 # Format-specific stripping helpers
 # ---------------------------------------------------------------------------
 
+# Allowlist of media types known to carry binary payloads (images, PDFs,
+# audio, video).  The base64 ``data`` field of a content block with one of
+# these media types decodes to opaque bytes that cannot contain text
+# secrets — but that DO trip the entropy detector and corrupt legitimate
+# content when redacted.  We only blank ``data`` when ``media_type`` is on
+# this allowlist so a field advertising itself as ``text/plain`` (or missing
+# a media type entirely) remains scannable for base64-encoded exfiltration.
+_BINARY_MEDIA_TYPE_PREFIXES = ("image/", "audio/", "video/")
+_BINARY_MEDIA_TYPES = frozenset({"application/pdf"})
+
+
+def _is_binary_media_type(media_type: str) -> bool:
+    if not isinstance(media_type, str) or not media_type:
+        return False
+    mt = media_type.lower().strip()
+    if any(mt.startswith(p) for p in _BINARY_MEDIA_TYPE_PREFIXES):
+        return True
+    return mt in _BINARY_MEDIA_TYPES
+
+
+def _blank_binary_image_data(block: dict) -> bool:
+    """Blank the base64 ``data`` field of image/document blocks with binary media.
+
+    The Anthropic content-block shape is
+    ``{"type":"image"|"document","source":{"type":"base64","media_type":"...","data":"..."}}``.
+    Only touches ``data`` — leaves ``media_type``, ``type``, and the rest of
+    the block intact so the upstream API still receives a valid request.
+    """
+    if not isinstance(block, dict):
+        return False
+    if block.get("type") not in ("image", "document"):
+        return False
+    source = block.get("source")
+    if not isinstance(source, dict):
+        return False
+    if source.get("type") != "base64":
+        return False
+    if not _is_binary_media_type(source.get("media_type", "")):
+        return False
+    data = source.get("data")
+    if not isinstance(data, str) or not data:
+        return False
+    source["data"] = ""
+    return True
+
+
+def _blank_binary_blocks(blocks: list) -> bool:
+    """Recursively blank binary image/document data in a content block list.
+
+    Descends into ``tool_result.content`` so image blocks nested inside a
+    tool result are also handled.
+    """
+    modified = False
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        modified = _blank_binary_image_data(block) or modified
+        if block.get("type") == "tool_result":
+            inner = block.get("content")
+            if isinstance(inner, list):
+                modified = _blank_binary_blocks(inner) or modified
+    return modified
+
 
 def _strip_messages_format(body: dict) -> bool:
     """Strip non-scannable content from OpenAI/Anthropic/Mistral message format.
@@ -450,7 +513,8 @@ def _strip_messages_format(body: dict) -> bool:
         if not isinstance(msg, dict):
             continue
 
-        # Keep the last user turn — strip only thinking blocks within it
+        # Keep the last user turn — strip only thinking blocks AND blank
+        # binary image/document data (high-entropy false positives).
         if i >= last_turn_start:
             content = msg.get("content")
             if isinstance(content, list):
@@ -460,6 +524,7 @@ def _strip_messages_format(body: dict) -> bool:
                             if key in block and block[key]:
                                 block[key] = ""
                                 modified = True
+                modified = _blank_binary_blocks(content) or modified
             continue
 
         # Blank all earlier messages
@@ -601,6 +666,8 @@ def _blank_message(msg: dict) -> bool:
                     if key in source and isinstance(source[key], str) and source[key]:
                         source[key] = ""
                         modified = True
+            # Anthropic image/document binary base64 data
+            modified = _blank_binary_image_data(block) or modified
 
     # OpenAI tool_calls — blank function arguments
     for tc in msg.get("tool_calls", []):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -10,6 +10,7 @@ from secretgate.scan import (
     BlockedError,
     SessionTokenHarvester,
     TextScanner,
+    _blank_binary_image_data,
     _blank_gemini_part,
     _strip_cohere,
     _strip_gemini,
@@ -511,6 +512,167 @@ class TestStripMessagesFormat:
         }
         _strip_messages_format(body)
         assert body["messages"][0]["content"][0]["content"] == []
+
+
+class TestBinaryImageData:
+    """Tests for blanking binary image/document data before scanning.
+
+    Claude Code vision was broken through secretgate because the entropy
+    detector fired on high-entropy base64 image payloads.  The fix blanks
+    the ``data`` field of image/document blocks when the ``media_type`` is
+    a known binary type (image/*, audio/*, video/*, application/pdf).
+    """
+
+    def test_blank_image_png_in_last_user_turn(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4",
+                            },
+                        },
+                        {"type": "text", "text": "what is this?"},
+                    ],
+                }
+            ]
+        }
+        _strip_messages_format(body)
+        img = body["messages"][0]["content"][0]
+        assert img["source"]["data"] == ""
+        # The rest of the block is preserved so the request stays valid
+        assert img["source"]["media_type"] == "image/png"
+        assert img["source"]["type"] == "base64"
+        assert img["type"] == "image"
+
+    def test_blank_document_pdf_in_last_user_turn(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": "JVBERi0xLjQKJeLjz9MK",
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+        _strip_messages_format(body)
+        assert body["messages"][0]["content"][0]["source"]["data"] == ""
+
+    def test_blank_image_nested_in_tool_result(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "abc",
+                            "content": [
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/jpeg",
+                                        "data": "/9j/4AAQSkZJRgABAQAAAQABAAD/",
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        _strip_messages_format(body)
+        nested = body["messages"][0]["content"][0]["content"][0]
+        assert nested["source"]["data"] == ""
+
+    def test_non_binary_media_type_not_blanked(self):
+        """text/plain or missing media_type leaves data scannable (exfiltration guard)."""
+        # text/plain — not in allowlist
+        block = {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "text/plain",
+                "data": "aGVsbG8=",
+            },
+        }
+        assert _blank_binary_image_data(block) is False
+        assert block["source"]["data"] == "aGVsbG8="
+
+        # Missing media_type — conservative default, not blanked
+        block2 = {
+            "type": "image",
+            "source": {"type": "base64", "data": "aGVsbG8="},
+        }
+        assert _blank_binary_image_data(block2) is False
+
+    def test_non_base64_source_not_touched(self):
+        """URL sources and other non-base64 source types are left alone."""
+        block = {
+            "type": "image",
+            "source": {"type": "url", "url": "https://example.com/img.png"},
+        }
+        assert _blank_binary_image_data(block) is False
+
+    def test_non_image_block_not_touched(self):
+        block = {"type": "text", "text": "hello"}
+        assert _blank_binary_image_data(block) is False
+
+    def test_scan_body_does_not_alert_on_image_png(self, redact_scanner):
+        """Integration: a high-entropy image payload in a real Anthropic
+        request must not trigger an alert (the entropy scanner previously
+        false-positived and corrupted the base64)."""
+        # Real-ish PNG preamble + long high-entropy base64 body
+        png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAA"
+            "ABCDEFabcdef0123456789+/AAABBBCCCDDDEEEFFFGGG"
+            "HHHIIIJJJKKKLLLMMMNNNOOOPPPQQQRRRSSSTTTUUUVVV"
+            "WWWXXXYYYZZZaaabbbcccdddeeefffggghhhiiijjjkkk"
+        )
+        payload = {
+            "model": "claude-sonnet-4-5",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": png_b64,
+                            },
+                        },
+                        {"type": "text", "text": "describe this"},
+                    ],
+                }
+            ],
+        }
+        body = json.dumps(payload).encode()
+        result, alerts = redact_scanner.scan_body(body, "application/json")
+        # No entropy false positive on the image data
+        assert alerts == []
+        # Outbound body is unchanged — the image reaches Anthropic intact.
+        # Blanking happens only on the scan-only copy, never on the wire.
+        out = json.loads(result.decode())
+        img = out["messages"][0]["content"][0]
+        assert img["type"] == "image"
+        assert img["source"]["media_type"] == "image/png"
+        assert img["source"]["data"] == png_b64
 
 
 class TestStripGemini:


### PR DESCRIPTION
## Summary

Claude Code vision was broken through the forward proxy: Anthropic returned \`400 invalid base64 data\` whenever a request contained an image. Root cause: the entropy detector false-positived on the high-entropy base64 payload inside \`image\`/\`document\` content blocks, the scanner then redacted substrings of the base64, and the corrupted payload was rejected by the API.

## Fix

Extend \`_strip_model_content\` to blank the \`source.data\` field of \`image\`/\`document\` blocks whose \`media_type\` is on a narrow binary allowlist:

- \`image/*\`
- \`audio/*\`
- \`video/*\`
- \`application/pdf\`

Blanking happens only on the scan-only copy — the original request bytes still reach the upstream intact.

## Why this is safe

The threat model is accidental leaks, not adversarial exfiltration. The exception is tightly scoped:

- Only inside the structural shape \`{"type":"image"|"document","source":{"type":"base64","media_type":"...","data":"..."}}\`
- Only when \`media_type\` is on the binary allowlist (Anthropic validates the declared type against the decoded bytes, so an attacker can't declare \`image/png\` and smuggle text)
- Blocks with \`text/plain\` or missing \`media_type\` remain fully scannable — base64-encoded exfiltration via generic JSON fields is still caught

Same discipline as existing exceptions (auth paths, thinking blocks, session JWTs): scoped to a specific structural position and a specific shape.

## Test plan

- [x] Unit tests for \`_blank_binary_image_data\` helper (allowlist, non-binary types, non-base64 sources, non-image blocks)
- [x] Unit test for nested \`tool_result.content\` image blocks
- [x] Integration test: high-entropy base64 image payload through \`scan_body\` produces no alerts AND the outbound body is unchanged
- [x] Full test suite (388 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)